### PR TITLE
add 'groups.json' and 'resources.json' to cluster-resources collector doc

### DIFF
--- a/content/reference/collectors/cluster-resources.md
+++ b/content/reference/collectors/cluster-resources.md
@@ -233,3 +233,92 @@ This file contains information about all pods, separated by namespace.
 
 ### /cluster-resources/ingress/\<namespace\>/\<name\>.json
 This file contains information about all ingresses, separated by namespace.
+
+### /cluster-resources/groups.json
+This file contains information about all kubernetes API resource groups in the cluster.
+
+```json
+[
+  {
+    "name": "",
+    "versions": [
+      {
+        "groupVersion": "v1",
+        "version": "v1"
+      }
+    ],
+    "preferredVersion": {
+      "groupVersion": "v1",
+      "version": "v1"
+    }
+  },
+  {
+    "name": "apiregistration.k8s.io",
+    "versions": [
+      {
+        "groupVersion": "apiregistration.k8s.io/v1",
+        "version": "v1"
+      },
+      {
+        "groupVersion": "apiregistration.k8s.io/v1beta1",
+        "version": "v1beta1"
+      }
+    ],
+    "preferredVersion": {
+      "groupVersion": "apiregistration.k8s.io/v1",
+      "version": "v1"
+    }
+  },
+```
+
+## /cluster-resources/resources.json
+This file contains information about all kubernetes API resources in the cluster.
+
+```json
+[
+  {
+    "kind": "APIResourceList",
+    "groupVersion": "v1",
+    "resources": [
+      {
+        "name": "bindings",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Binding",
+        "verbs": [
+          "create"
+        ]
+      },
+      {
+        "name": "componentstatuses",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "ComponentStatus",
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "shortNames": [
+          "cs"
+        ]
+      },
+      {
+        "name": "configmaps",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ConfigMap",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "cm"
+        ]
+      },
+```

--- a/content/reference/collectors/cluster-resources.md
+++ b/content/reference/collectors/cluster-resources.md
@@ -237,6 +237,7 @@ This file contains information about all ingresses, separated by namespace.
 ### /cluster-resources/groups.json
 This file contains information about all kubernetes API resource groups in the cluster.
 
+The below is a partial example only, and real results will be significantly longer.
 ```json
 [
   {
@@ -269,11 +270,13 @@ This file contains information about all kubernetes API resource groups in the c
       "version": "v1"
     }
   },
+...
 ```
 
 ## /cluster-resources/resources.json
 This file contains information about all kubernetes API resources in the cluster.
 
+The below is a partial example only, and real results will be significantly longer.
 ```json
 [
   {
@@ -321,4 +324,5 @@ This file contains information about all kubernetes API resources in the cluster
           "cm"
         ]
       },
+...
 ```


### PR DESCRIPTION
github chokes on the render due to invalid JSON (only the first part of the structs are included as examples) but Hugo does fine

![image](https://user-images.githubusercontent.com/2318911/72031943-d4f0c280-3242-11ea-9afe-18d510f4e4da.png)

