### PR TITLE
Fix issues with section aliases (e.g., /preflight)

### DIFF
--- a/content/preflight/creating.md
+++ b/content/preflight/creating.md
@@ -1,8 +1,8 @@
 ---
 date: "2019-11-27"
 title: "Defining Preflights"
-linktitle: creating
-description: "Defining Preflight"
+linktitle: "Defining Preflights"
+description: "Defining Preflights"
 weight: 30090
 aliases:
   - /docs/preflight/creating

--- a/content/preflight/executing.md
+++ b/content/preflight/executing.md
@@ -1,7 +1,7 @@
 ---
 date: 2019-10-09
-title: Executing Preflight Checks
-linktitle: executing
+title: "Executing Preflight Checks"
+linktitle: "Executing Preflight Checks"
 weight: 30020
 aliases:
   - /docs/preflight/executing

--- a/content/preflight/other-installation-options.md
+++ b/content/preflight/other-installation-options.md
@@ -1,7 +1,7 @@
 ---
 date: 2019-10-09
-title: Other Installation Options
-linktitle: other-installation-options
+title: "Other Installation Options"
+linktitle: "Other Installation Options"
 weight: 30030
 aliases:
   - /docs/preflight/other-installation-options

--- a/content/preflight/overview.md
+++ b/content/preflight/overview.md
@@ -1,10 +1,9 @@
 ---
 date: 2019-10-09
-title: Preflight Checks
-linktitle: overview
+title: "Preflight Checks"
+linktitle: "Preflight Overview"
 weight: 30010
 aliases:
-  - /preflight
   - /docs/preflight/overview
 ---
 

--- a/content/reference/_index.md
+++ b/content/reference/_index.md
@@ -1,7 +1,0 @@
----
-date: "2019-09-30T00:00:00Z"
-lastmod: "2019-09-30T00:00:00Z"
-title: "Troubleshoot Reference Documentation"
-weight: "2"
----
-

--- a/content/reference/analyzers/overview.md
+++ b/content/reference/analyzers/overview.md
@@ -1,8 +1,10 @@
 ---
 date: 2019-11-01
 linktitle: "Analyzers Overview"
-title: Analyzers Overview
+title: "Analyzers Overview"
 weight: 20010
+aliases:
+  - /reference/analyzers
 ---
 
 

--- a/content/reference/collectors/overview.md
+++ b/content/reference/collectors/overview.md
@@ -1,8 +1,10 @@
 ---
 date: 2019-10-23
-linktitle: "Overview"
-title: Collectors Overview
+linktitle: "Collectors Overview"
+title: "Collectors Overview"
 weight: 20010
+aliases:
+  - /reference/collectors
 ---
 
 Collectors are YAML specifications that define which data to collect when generating a support bundle or when running preflight checks on a cluster.

--- a/content/reference/getting-started/overview.md
+++ b/content/reference/getting-started/overview.md
@@ -1,8 +1,10 @@
 ---
 date: 2019-10-09
 linktitle: "Overview"
-title: Overview of Troubleshoot
+title: "Overview of Troubleshoot"
 weight: 20010
+aliases:
+  - /reference/getting-started
 ---
 
 

--- a/content/support-bundle/collecting.md
+++ b/content/support-bundle/collecting.md
@@ -1,7 +1,7 @@
 ---
 date: 2019-10-09
-title: Collecting Support Bundles
-linktitle: collecting
+title: "Collecting Support Bundles"
+linktitle: "Collecting Support Bundles"
 weight: 40020
 aliases:
   - /docs/support-bundle/collecting

--- a/content/support-bundle/overview.md
+++ b/content/support-bundle/overview.md
@@ -1,10 +1,9 @@
 ---
 date: 2019-10-09
-title: Support Bundle
-linktitle: overview
+title: "Support Bundle"
+linktitle: "Support Bundle Overview"
 weight: 40010
 aliases:
-  - /support-bundle/
   - /docs/support-bundle/overview
 ---
 

--- a/content/support-bundle/redact.md
+++ b/content/support-bundle/redact.md
@@ -1,7 +1,7 @@
 ---
 date: 2019-10-09
-title: Redaction
-linktitle: redact
+title: "Redaction"
+linktitle: "Redaction"
 weight: 40030
 aliases:
   - /docs/support-bundle/redact

--- a/themes/hugo-whisper-theme/layouts/index.html
+++ b/themes/hugo-whisper-theme/layouts/index.html
@@ -48,7 +48,7 @@
               <div>
                 <div class="content flex flex-column">
                   <code >curl https://krew.sh/preflight | bash</code>
-                  <code> kubectl preflight https://preflight.myapp.com</code>
+                  <code> kubectl preflight https://preflight.replicated.com</code>
                 </div>
               </div>
               </div>

--- a/themes/hugo-whisper-theme/layouts/partials/sidebar.html
+++ b/themes/hugo-whisper-theme/layouts/partials/sidebar.html
@@ -4,7 +4,7 @@
   <h3>
     <a href="{{ .FirstSection.Params.redirect }}">
       {{ if eq .Section "reference" }}
-        Reference Documentation
+        Reference
       {{ else }}
         {{ .Section | humanize }} 
       {{ end }}

--- a/themes/hugo-whisper-theme/layouts/section/preflight.html
+++ b/themes/hugo-whisper-theme/layouts/section/preflight.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html><html>
+    <head>
+        <title>/preflight/overview</title>
+        <link rel="canonical" href="/preflight/overview"/>
+        <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+        <meta http-equiv="refresh" content="0; url=/preflight/overview" />
+    </head>
+</html>

--- a/themes/hugo-whisper-theme/layouts/section/reference.html
+++ b/themes/hugo-whisper-theme/layouts/section/reference.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html><html>
+    <head>
+        <title>/reference/getting-started/overview</title>
+        <link rel="canonical" href="/reference/getting-started/overview"/>
+        <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+        <meta http-equiv="refresh" content="0; url=/reference/getting-started/overview" />
+    </head>
+</html>

--- a/themes/hugo-whisper-theme/layouts/section/support-bundle.html
+++ b/themes/hugo-whisper-theme/layouts/section/support-bundle.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html><html>
+    <head>
+        <title>/support-bundle/overview</title>
+        <link rel="canonical" href="/support-bundle/overview"/>
+        <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+        <meta http-equiv="refresh" content="0; url=/support-bundle/overview" />
+    </head>
+</html>


### PR DESCRIPTION
It's not possible to alias section names, so despite being aliased, links to /preflight, /support-bundle, and /reference is not working. 

Fixed by creating html to redirect to designated page for a section. Also fixed link titles, and the reference to "myapp" (which should be replicated). 