### PR TITLE
Fix support bundle instructions on landing page

### DIFF
--- a/themes/hugo-whisper-theme/layouts/index.html
+++ b/themes/hugo-whisper-theme/layouts/index.html
@@ -71,7 +71,7 @@
                 <div class="row"><p style="margin-bottom:12px; font-size:16px;">Install on your workstation:</p></div>
                 <div>
                   <div class="content flex flex-column">
-                    <code >curl https://krew.sh/support-bundle</code>
+                    <code>curl https://krew.sh/support-bundle | bash</code>
                     <code> kubectl support-bundle https://support.myapp.com</code>
                   </div>
                 </div>


### PR DESCRIPTION
Small fix to the `support-bundle` instructions on the landing page