### PR TITLE
Fixing HtmlProofer CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       with: 
         args: -v -s .
     - name: Check HTML
-      uses: chabad360/htmlproofer@v1.1
+      uses: austinchambers/htmlproofer@v1.2
       with:
         # The directory to scan
         directory: "./public"


### PR DESCRIPTION
 It looks like we didn’t have invalid html after all. htmlproofer rolled a broken patch release :facepalm: . I figured it was safe to be on the patch-only channel. Guess I was wrong. Fixed by rolling my own image and locking at current fix version.