### PR TITLE
textAnalyze uses fileName not filename

### DIFF
--- a/content/reference/analyzers/regex.md
+++ b/content/reference/analyzers/regex.md
@@ -32,7 +32,7 @@ spec:
 
     - textAnalyze:
         checkName: "run-ping"
-        filename: run/ping.txt
+        fileName: run/ping.txt
         data: '{{repl ConfigOption "replica_count" }}'
         regexGroups: '(?P<Transmitted>\d+) packets? transmitted, (?P<Received>\d+) packets? received, (?P<Loss>\d+\.\d+)% packet loss'
         outcomes:


### PR DESCRIPTION
see https://github.com/replicatedhq/troubleshoot/blob/8f78827002b42fffd5187464fb9e46d950eb4ed0/pkg/apis/troubleshoot/v1beta1/analyzer_shared.go#L100