### PR TITLE
Ensuring that we download a linux version of the installer when it's not darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ deps:
 	   echo '-> Downloading Hugo CLI to ./deps '; \
 	   mkdir -p deps/; \
 	   if [[ "$(dist)" == "darwin" ]]; then \
-	     wget -O hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v0.68.3/hugo_0.68.3_macOS-64bit.tar.gz; \
+	     wget -O hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/$(upstream_version)/hugo_0.68.3_macOS-64bit.tar.gz; \
 	   else \
-	     wget -O hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v0.68.3/hugo_0.68.3_Linux-64bit.tar.gz; \
+	     wget -O hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/$(upstream_version)/hugo_0.68.3_Linux-64bit.tar.gz; \
 	   fi; \
 	   tar xvzf hugo.tar.gz -C deps; \
 	 fi;

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,31 @@
 SHELL := /bin/bash -o pipefail
 
-.PHONY: deps
-deps: 
+.PHONY: deps-proofer
+deps-proofer: 
 	gem install --user-install html-proofer -v 3.15.0
 
-	echo '-> Downloading Hugo to ./deps '; \
-	mkdir -p deps/; \
-	cd deps/; \
-	wget -O hugo_maxOs-64bit.tar.gz https://github.com/gohugoio/hugo/releases/download/v0.68.3/hugo_0.68.3_macOS-64bit.tar.gz; \
-	tar -xvzf hugo_maxOs-64bit.tar.gz; 
+.PHONY: deps
+deps: upstream_version = "v0.68.3"
+deps: dist = $(shell echo `uname` | tr '[:upper:]' '[:lower:]')
+deps: cli_version = ""
+deps: cli_version = $(shell [[ -x deps/hugo ]] && deps/hugo version | sed 's/\-/ /g' | sed 's/\// /g' | awk '{print $$5}' )
+
+deps:
+	: CLI Local Version $(cli_version)
+	: CLI Upstream Version $(upstream_version)
+	: Dist $(dist)
+	@if [[ "$(cli_version)" == "$(upstream_version)" ]]; then \
+	   echo "Hugo version $(upstream_version) already present"; \
+	 else \
+	   echo '-> Downloading Hugo CLI to ./deps '; \
+	   mkdir -p deps/; \
+	   if [[ "$(dist)" == "darwin" ]]; then \
+	     wget -O hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v0.68.3/hugo_0.68.3_macOS-64bit.tar.gz; \
+	   else \
+	     wget -O hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v0.68.3/hugo_0.68.3_Linux-64bit.tar.gz; \
+	   fi; \
+	   tar xvzf hugo.tar.gz -C deps; \
+	 fi;
 
 .PHONY: index-site
 index-site:
@@ -22,12 +39,12 @@ index-and-send:
 install:
 	yarn --pure-lockfile
 
-.PHONY: dev
-dev:
+.PHONY: dev 
+dev: deps
 	deps/hugo serve --theme hugo-whisper-theme
 
-.PHONY: test deps
-test:
+.PHONY: test
+test: deps deps-proofer
 	rm -rf public
 	deps/hugo -v -s .
 	htmlproofer --allow-hash-href --check-html --empty-alt-ignore --url-ignore /kots.io/css/ "./public"


### PR DESCRIPTION
There was an earlier problem where the local copy of hugo was different than what netlify used, which created problems. When I addressed that, I only included the darwin binary. We should detect the os and get the appropriate binary (whether linux or macOs).

This way, it will work with codeserver