### PR TITLE
Add ingress analyzer

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -72,6 +72,7 @@ const themeOptions = {
               'analyze/deployment-status',
               'analyze/statefulset-status',
               'analyze/image-pull-secrets',
+              'analyze/ingress',
               'analyze/storage-class',
               'analyze/secrets',
               'analyze/crd',

--- a/docs/source/analyze/ingress.md
+++ b/docs/source/analyze/ingress.md
@@ -20,7 +20,7 @@ spec:
         ingressName: connect-to-me
         outcomes:
           - fail:
-              message: The ingress isn't listed in  the cluster
+              message: The ingress isn't listed in the cluster
           - pass:
               message: Ingress rule found
 ```

--- a/docs/source/analyze/ingress.md
+++ b/docs/source/analyze/ingress.md
@@ -3,6 +3,8 @@ title: Ingress
 description: Analyzing the what is this
 ---
 
+Ingress Analyzer checks if a given Ingress is listed in the cluster resources in a given namespace
+
 ```yaml
 apiVersion: troubleshoot.sh/v1beta2
 kind: Preflight
@@ -15,9 +17,9 @@ spec:
         ingressName: connect-to-me
         outcomes:
           - fail:
-              message: The ingress isn't ingressing
+              message: The ingress isn't listed in  the cluster
           - pass:
-              message: All systems ok on ingress
+              message: Ingress rule found
 ```
 
 > Note: `troubleshoot.sh/v1beta2` was introduced in preflight and support-bundle krew plugin version 0.9.39 and Kots version 1.19.0. Kots vendors should [read the guide to maintain backwards compatibility](/v1beta2/).

--- a/docs/source/analyze/ingress.md
+++ b/docs/source/analyze/ingress.md
@@ -5,6 +5,9 @@ description: Analyzer to check for the presence of Ingress rules
 
 Ingress Analyzer checks if a given Ingress is listed within the cluster resources in a given namespace.
 
+> `Ingress` was introduced in Kots 1.20.0 and Troubleshoot 0.9.43.
+
+
 ```yaml
 apiVersion: troubleshoot.sh/v1beta2
 kind: Preflight

--- a/docs/source/analyze/ingress.md
+++ b/docs/source/analyze/ingress.md
@@ -3,7 +3,7 @@ title: Ingress
 description: Analyzing the what is this
 ---
 
-Ingress Analyzer checks if a given Ingress is listed in the cluster resources in a given namespace
+Ingress Analyzer checks if a given Ingress is listed within the cluster resources in a given namespace.
 
 ```yaml
 apiVersion: troubleshoot.sh/v1beta2

--- a/docs/source/analyze/ingress.md
+++ b/docs/source/analyze/ingress.md
@@ -1,6 +1,6 @@
 ---
 title: Ingress
-description: Analyzing the what is this
+description: Analyzer to check for the presence of Ingress rules
 ---
 
 Ingress Analyzer checks if a given Ingress is listed within the cluster resources in a given namespace.

--- a/docs/source/analyze/ingress.md
+++ b/docs/source/analyze/ingress.md
@@ -1,0 +1,23 @@
+---
+title: Ingress
+description: Analyzing the what is this
+---
+
+```yaml
+apiVersion: troubleshoot.sh/v1beta2
+kind: Preflight
+metadata:
+  name: preflight-sample
+spec:
+  analyzers:
+    - ingress:
+        namespace: default
+        ingressName: connect-to-me
+        outcomes:
+          - fail:
+              message: The ingress isn't ingressing
+          - pass:
+              message: All systems ok on ingress
+```
+
+> Note: `troubleshoot.sh/v1beta2` was introduced in preflight and support-bundle krew plugin version 0.9.39 and Kots version 1.19.0. Kots vendors should [read the guide to maintain backwards compatibility](/v1beta2/).


### PR DESCRIPTION
@markpundsack Hi Mark! I think I've restored all ingress info. I modified the example because I think it was misleading. "Ingress isn't ingressing" gives me the impression that the rule is actually tested (for example, by checking the connection) and what the analyzer actually does is checking the list of ingress rules. I am not sure if the existence of such rule implies that the connection is ok. 

Let me know what you think!