### PR TITLE
fix indentation

### DIFF
--- a/docs/source/analyze/regex.md
+++ b/docs/source/analyze/regex.md
@@ -36,16 +36,16 @@ spec:
         name: my-app
   analyzers:
     - textAnalyze:
-      checkName: Database Authentication
-      fileName: my-app/my-app-0/my-app.log
-      regex: 'FATAL: password authentication failed for user'
-      outcomes:
-        - pass:
-            when: "false"
-            message: "Database credentials okay"
-        - fail:
-            when: "true"
-            message: "Problem with database credentials"
+        checkName: Database Authentication
+        fileName: my-app/my-app-0/my-app.log
+        regex: 'FATAL: password authentication failed for user'
+        outcomes:
+          - pass:
+              when: "false"
+              message: "Database credentials okay"
+          - fail:
+              when: "true"
+              message: "Problem with database credentials"
 ```
 
 ## Example Analyzer Definition for regexGroups


### PR DESCRIPTION
- This [example](https://troubleshoot.sh/docs/analyze/regex/#example-analyzer-definition-for-regex) has the wrong indentation. 
- I validated that this edit is valid and works 