### PR TITLE
clarify time units in logs collector

### DIFF
--- a/docs/source/collect/logs.md
+++ b/docs/source/collect/logs.md
@@ -56,6 +56,7 @@ Either `maxAge` or `maxLines` can be provided, but not both.
 
 ##### `limits.maxAge`
 The duration of the maximum oldest log to include.
+Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 For duration string format see [time.ParseDuration](https://pkg.go.dev/time#ParseDuration).
 
 ##### `limits.maxLines`
@@ -80,8 +81,15 @@ spec:
           - node
         limits:
           maxAge: 720h
+    - logs:
+        selector:
+          - app=backend
+        namespace: default
+        name: backend/container/logs
+        containerNames:
+          - db
+        limits:
           maxLines: 1000
-
 ```
 
 


### PR DESCRIPTION
surface the units you can use to express time for maxAge and refactor the example into two cases, one for maxAge and one for maxLines, since the limits: field only respects one of the two and the original example was misleading