### PR TITLE
docs for new YAML and JSON compare analyzers

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -88,6 +88,8 @@ const themeOptions = {
               'analyze/secrets',
               'analyze/crd',
               'analyze/regex',
+              'analyze/json-compare',
+              'analyze/yaml-compare',
               'analyze/postgresql',
               'analyze/mysql',
               'analyze/ceph-status',

--- a/docs/source/analyze/json-compare.md
+++ b/docs/source/analyze/json-compare.md
@@ -1,6 +1,6 @@
 ---
 title: JSON Compare
-description: Compare JSON values
+description: Compare JSON snippets
 ---
 
 The JSON compare analyzer is used to compare a JSON snippet with part or all of a collected JSON file.
@@ -10,8 +10,8 @@ The JSON compare analyzer is used to compare a JSON snippet with part or all of 
 **fileName**: (Required) Path of the collected file to analyze.
 
 **value**: (Required) JSON value to compare.
-If the value matches the collected file, the outcome that has set `when` to `"true"` will be executed.
-If no `when` expression has been specified, the `pass` outcome defaults to `"true"`.
+If the value matches the collected file, the outcome that has `when` set to `"true"` will be executed.
+If no `when` expression is specified, the `pass` outcome defaults to `"true"`.
 
 **path**: (Optional) Portion of the collected JSON file to compare against.
 The default behavior is to compare against the entire collected file.

--- a/docs/source/analyze/json-compare.md
+++ b/docs/source/analyze/json-compare.md
@@ -1,18 +1,18 @@
 ---
 title: JSON Compare
-description: Compare JSON snippets
+description: Compare JSON values
 ---
 
 The JSON compare analyzer is used to compare a JSON snippet with part or all of a collected JSON file.
 
 ## Parameters
 
-**fileName** (Required) Path to the file in support bundle to analyze.
+**fileName**: (Required) Path to the file in support bundle to analyze.
 
-**value** (Required) JSON value to compare.
+**value**: (Required) JSON value to compare.
 If the value matches the collected file, the outcome that has set `when` to `"true"` will be executed.
 
-**path** (Optional) Portion of the collected JSON file to compare against.
+**path**: (Optional) Portion of the collected JSON file to compare against.
 The default behavior is to compare against the entire collected file.
 
 ## Example Analyzer Definition

--- a/docs/source/analyze/json-compare.md
+++ b/docs/source/analyze/json-compare.md
@@ -1,0 +1,25 @@
+---
+title: JSON Compare
+description: Compare JSON snippets
+---
+
+The JSON compare analyzer is used to compare a JSON snippet with part or all of a collected JSON file.
+
+## Parameters
+
+**data:** Describe this and other parameters here.
+
+## Example Analyzer Definition
+
+```yaml
+apiVersion: troubleshoot.sh/v1beta2
+kind: Preflight
+metadata:
+  name: json-compare-sample
+spec:
+  collectors:
+    
+  analyzers:
+    - jsonCompare:
+        
+```

--- a/docs/source/analyze/json-compare.md
+++ b/docs/source/analyze/json-compare.md
@@ -7,7 +7,13 @@ The JSON compare analyzer is used to compare a JSON snippet with part or all of 
 
 ## Parameters
 
-**data:** Describe this and other parameters here.
+**fileName** (Required) Path to the file in support bundle to analyze.
+
+**value** (Required) JSON value to compare.
+If the value matches the collected file, the outcome that has set `when` to `"true"` will be executed.
+
+**path** (Optional) Portion of the collected JSON file to compare against.
+The default behavior is to compare against the entire collected file.
 
 ## Example Analyzer Definition
 
@@ -15,11 +21,64 @@ The JSON compare analyzer is used to compare a JSON snippet with part or all of 
 apiVersion: troubleshoot.sh/v1beta2
 kind: Preflight
 metadata:
-  name: json-compare-sample
+  name: json-compare-example
 spec:
   collectors:
-    
+    - data:
+        name: example.json
+        data: |
+          {
+            "foo": "bar",
+            "stuff": {
+              "foo": "bar",
+              "bar": true
+            },
+            "morestuff": [
+              {
+                "foo": {
+                  "bar": 123
+                }
+              }
+            ]
+          }
   analyzers:
     - jsonCompare:
-        
+        checkName: Compare JSON Example
+        fileName: example.json
+        path: "morestuff.[0].foo.bar"
+        value: |
+          123
+        outcomes:
+          - fail:
+              when: "false"
+              message: The collected data does not match the value
+          - pass:
+              when: "true"
+              message: The collected data matches the value
+```
+
+## Example Analyzer Definition to Check the Cluster Platform
+
+```yaml
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: json-compare-example
+spec:
+  collectors:
+    - clusterInfo: {}
+  analyzers:
+    - jsonCompare:
+        checkName: Check Cluster Platform
+        fileName: cluster-info/cluster_version.json
+        path: "info.platform"
+        value: |
+          "linux/amd64"
+        outcomes:
+          - fail:
+              when: "false"
+              message: The cluster platform is not linux/amd64
+          - pass:
+              when: "true"
+              message: The cluster platform is linux/amd64
 ```

--- a/docs/source/analyze/json-compare.md
+++ b/docs/source/analyze/json-compare.md
@@ -7,10 +7,11 @@ The JSON compare analyzer is used to compare a JSON snippet with part or all of 
 
 ## Parameters
 
-**fileName**: (Required) Path to the file in support bundle to analyze.
+**fileName**: (Required) Path of the collected file to analyze.
 
 **value**: (Required) JSON value to compare.
 If the value matches the collected file, the outcome that has set `when` to `"true"` will be executed.
+If no `when` expression has been specified, the `pass` outcome defaults to `"true"`.
 
 **path**: (Optional) Portion of the collected JSON file to compare against.
 The default behavior is to compare against the entire collected file.

--- a/docs/source/analyze/json-compare.md
+++ b/docs/source/analyze/json-compare.md
@@ -11,7 +11,7 @@ The JSON compare analyzer is used to compare a JSON snippet with part or all of 
 
 **value**: (Required) JSON value to compare.
 If the value matches the collected file, the outcome that has `when` set to `"true"` will be executed.
-If no `when` expression is specified, the `pass` outcome defaults to `"true"`.
+If a `when` expression is not specified, the `pass` outcome defaults to `"true"`.
 
 **path**: (Optional) Portion of the collected JSON file to compare against.
 The default behavior is to compare against the entire collected file.
@@ -52,10 +52,10 @@ spec:
         outcomes:
           - fail:
               when: "false"
-              message: The collected data does not match the value
+              message: The collected data does not match the value.
           - pass:
               when: "true"
-              message: The collected data matches the value
+              message: The collected data matches the value.
 ```
 
 ## Example Analyzer Definition to Check the Cluster Platform
@@ -78,8 +78,8 @@ spec:
         outcomes:
           - fail:
               when: "false"
-              message: The cluster platform is not linux/amd64
+              message: The cluster platform is not linux/amd64.
           - pass:
               when: "true"
-              message: The cluster platform is linux/amd64
+              message: The cluster platform is linux/amd64.
 ```

--- a/docs/source/analyze/yaml-compare.md
+++ b/docs/source/analyze/yaml-compare.md
@@ -11,7 +11,7 @@ The YAML compare analyzer is used to compare a YAML snippet with part or all of 
 
 **value**: (Required) YAML value to compare.
 If the value matches the collected file, the outcome that has `when` set to `"true"` will be executed.
-If no `when` expression is specified, the `pass` outcome defaults to `"true"`.
+If a `when` expression is not specified, the `pass` outcome defaults to `"true"`.
 
 **path**: (Optional) Portion of the collected YAML file to compare against.
 The default behavior is to compare against the entire collected file.
@@ -45,8 +45,8 @@ spec:
         outcomes:
           - fail:
               when: "false"
-              message: The collected data does not match the value
+              message: The collected data does not match the value.
           - pass:
               when: "true"
-              message: The collected data matches the value
+              message: The collected data matches the value.
 ```

--- a/docs/source/analyze/yaml-compare.md
+++ b/docs/source/analyze/yaml-compare.md
@@ -10,8 +10,8 @@ The YAML compare analyzer is used to compare a YAML snippet with part or all of 
 **fileName**: (Required) Path of the collected file to analyze.
 
 **value**: (Required) YAML value to compare.
-If the value matches the collected file, the outcome that has set `when` to `"true"` will be executed.
-If no `when` expression has been specified, the `pass` outcome defaults to `"true"`.
+If the value matches the collected file, the outcome that has `when` set to `"true"` will be executed.
+If no `when` expression is specified, the `pass` outcome defaults to `"true"`.
 
 **path**: (Optional) Portion of the collected YAML file to compare against.
 The default behavior is to compare against the entire collected file.

--- a/docs/source/analyze/yaml-compare.md
+++ b/docs/source/analyze/yaml-compare.md
@@ -7,7 +7,13 @@ The YAML compare analyzer is used to compare a YAML snippet with part or all of 
 
 ## Parameters
 
-**data:** Describe this and other parameters here.
+**fileName** (Required) Path to the file in support bundle to analyze.
+
+**value** (Required) YAML value to compare.
+If the value matches the collected file, the outcome that has set `when` to `"true"` will be executed.
+
+**path** (Optional) Portion of the collected YAML file to compare against.
+The default behavior is to compare against the entire collected file.
 
 ## Example Analyzer Definition
 
@@ -15,11 +21,31 @@ The YAML compare analyzer is used to compare a YAML snippet with part or all of 
 apiVersion: troubleshoot.sh/v1beta2
 kind: Preflight
 metadata:
-  name: yaml-compare-sample
+  name: yaml-compare-example
 spec:
   collectors:
-    
+    - data:
+        name: example.yaml
+        data: |
+          foo: bar
+          stuff:
+            foo: bar
+            bar: foo
+          morestuff:
+          - foo:
+              bar: 123
   analyzers:
     - yamlCompare:
-        
+        checkName: Compare YAML Example
+        fileName: example.yaml
+        path: "morestuff.[0].foo"
+        value: |
+          bar: 123
+        outcomes:
+          - fail:
+              when: "false"
+              message: The collected data does not match the value
+          - pass:
+              when: "true"
+              message: The collected data matches the value
 ```

--- a/docs/source/analyze/yaml-compare.md
+++ b/docs/source/analyze/yaml-compare.md
@@ -7,12 +7,12 @@ The YAML compare analyzer is used to compare a YAML snippet with part or all of 
 
 ## Parameters
 
-**fileName** (Required) Path to the file in support bundle to analyze.
+**fileName**: (Required) Path to the file in support bundle to analyze.
 
-**value** (Required) YAML value to compare.
+**value**: (Required) YAML value to compare.
 If the value matches the collected file, the outcome that has set `when` to `"true"` will be executed.
 
-**path** (Optional) Portion of the collected YAML file to compare against.
+**path**: (Optional) Portion of the collected YAML file to compare against.
 The default behavior is to compare against the entire collected file.
 
 ## Example Analyzer Definition

--- a/docs/source/analyze/yaml-compare.md
+++ b/docs/source/analyze/yaml-compare.md
@@ -1,0 +1,25 @@
+---
+title: YAML Compare
+description: Compare YAML snippets
+---
+
+The YAML compare analyzer is used to compare a YAML snippet with part or all of a collected YAML file.
+
+## Parameters
+
+**data:** Describe this and other parameters here.
+
+## Example Analyzer Definition
+
+```yaml
+apiVersion: troubleshoot.sh/v1beta2
+kind: Preflight
+metadata:
+  name: yaml-compare-sample
+spec:
+  collectors:
+    
+  analyzers:
+    - yamlCompare:
+        
+```

--- a/docs/source/analyze/yaml-compare.md
+++ b/docs/source/analyze/yaml-compare.md
@@ -7,10 +7,11 @@ The YAML compare analyzer is used to compare a YAML snippet with part or all of 
 
 ## Parameters
 
-**fileName**: (Required) Path to the file in support bundle to analyze.
+**fileName**: (Required) Path of the collected file to analyze.
 
 **value**: (Required) YAML value to compare.
 If the value matches the collected file, the outcome that has set `when` to `"true"` will be executed.
+If no `when` expression has been specified, the `pass` outcome defaults to `"true"`.
 
 **path**: (Optional) Portion of the collected YAML file to compare against.
 The default behavior is to compare against the entire collected file.


### PR DESCRIPTION
I added the new pages to the sidebar beneath the regex text analyzer since these seem somewhat related.  Also tried to include a more realistic example in the JSON compare page.  I don't have a great real-world example for the YAML compare at the moment, but is something I can add later.