### PR TITLE
Document "absent" keyword

### DIFF
--- a/docs/source/analyze/deployment-status.md
+++ b/docs/source/analyze/deployment-status.md
@@ -37,6 +37,9 @@ spec:
         namespace: default
         outcomes:
           - fail:
+              when: "absent" # note that the "absent" failure state must be listed first if used.
+              message: The API deployment is not present.
+          - fail:
               when: "< 1"
               message: The API deployment does not have any ready replicas.
           - warn:
@@ -45,3 +48,5 @@ spec:
           - pass:
               message: There are multiple replicas of the API deployment ready.
 ```
+
+## Example

--- a/docs/source/analyze/statefulset-status.md
+++ b/docs/source/analyze/statefulset-status.md
@@ -42,6 +42,9 @@ spec:
         namespace: default
         outcomes:
           - fail:
+              when: "absent" # note that the "absent" failure state must be listed first if used.
+              message: The redis statefulset is not present.
+          - fail:
               when: "< 1"
               message: The redis statefulset does not have any ready replicas.
           - warn:


### PR DESCRIPTION
The "absent" keyword was added to the deployment-status and statefulset-status analyzers in https://github.com/replicatedhq/troubleshoot/pull/644