### PR TITLE
Troubleshoot with Multiple Specs

### DIFF
--- a/docs/source/preflight/cluster-checks.md
+++ b/docs/source/preflight/cluster-checks.md
@@ -168,3 +168,20 @@ After collecting and analyzing, you'll see a screen similar to below:
 You can use the arrow keys to move up and down to select different preflight checks and see the results.
 
 Again, press `q` to exit when finished.
+
+## Run preflights using multiple specs
+> Introduced in Troubleshoot v0.42.0
+
+You may need to run preflights using the collectors and analyzers specified in multiple different specs. As of Troubleshoot `v0.42.0`, you can now pass multiple specs as arguments to the `preflight` CLI.
+
+Run preflights using multiple specs from the filesystem
+ ```shell
+./preflight ./preflight-1.yaml ./preflight-2.yaml
+ ```
+
+Run preflights using a spec from a URL, a file, and from a Kubernetes secret
+ ```shell
+./preflight https://raw.githubusercontent.com/replicatedhq/troubleshoot/main/examples/preflight/sample-preflight.yaml \
+./preflight-1.yaml \
+secret/path/to/my/spec 
+ ```

--- a/docs/source/preflight/cluster-checks.md
+++ b/docs/source/preflight/cluster-checks.md
@@ -170,9 +170,9 @@ You can use the arrow keys to move up and down to select different preflight che
 Again, press `q` to exit when finished.
 
 ## Run preflights using multiple specs
-> Introduced in Troubleshoot v0.42.0
+> Introduced in Troubleshoot v0.50.0
 
-You may need to run preflights using the collectors and analyzers specified in multiple different specs. As of Troubleshoot `v0.42.0`, you can now pass multiple specs as arguments to the `preflight` CLI.
+You may need to run preflights using the collectors and analyzers specified in multiple different specs. As of Troubleshoot `v0.50.0`, you can now pass multiple specs as arguments to the `preflight` CLI.
 
 Run preflights using multiple specs from the filesystem
  ```shell

--- a/docs/source/preflight/introduction.md
+++ b/docs/source/preflight/introduction.md
@@ -17,4 +17,4 @@ By completing this tutorial, you will know how to write Preflight Checks, includ
 Before starting this tutorial, you should have the following:
 
 1. The Troubleshoot plugins [installed](/#installation).
-1. A Kubernetes cluster and local kubectl access to the cluster. If you don't have one for testing, consider [kURL](https://kurl.sh), [KiND](https://github.com/kubernetes-sigs/kind), or [K3S](https://k3s.io).
+2. A Kubernetes cluster and local kubectl access to the cluster. If you don't have one for testing, consider [kURL](https://kurl.sh), [KiND](https://github.com/kubernetes-sigs/kind), or [K3S](https://k3s.io).

--- a/docs/source/preflight/next-steps.md
+++ b/docs/source/preflight/next-steps.md
@@ -17,7 +17,6 @@ There are several ways to include Preflight Checks in your application.
 #### KOTS
 If you are packing a [KOTS](https://kots.io) application, you can simply include a `kind: Preflight` document in your application and the KOTS Admin Console will show a browser-based representation of the Preflight results.
 
-
 #### Documentation Only
 Another approach to including Preflight Checks is to host the Preflight YAML on a server (even a GitHub Gist) and include instructions to manually run them before installing.
 Adding this to your installation documentation is just asking the user to run `kubectl preflight <https-your-server/preflight.yaml>.

--- a/docs/source/support-bundle/collecting.md
+++ b/docs/source/support-bundle/collecting.md
@@ -3,6 +3,7 @@ title: Collecting a Support Bundle
 description: Learn how to collect a support bundle
 ---
 
+## Collect a support bundle
 Now that we have the `kubectl` plugin installed, let's collect a support bundle.
 
 A support bundle needs to know what to collect and optionally, what to analyze.
@@ -34,4 +35,24 @@ In my case, the file created was named `support-bundle.tar.gz`.
 
 You can `tar xzvf` the file and open it in your editor to look at the contents.
 
-For Troubleshoot v0.47.0 and later, you can also use the `--load-cluster-specs` flag with the `support-bundle` CLI to collect a Support Bundle by automatically discovering Support Bundle and Redactor specs in Secrets and ConfigMaps in the cluster. For more information, see [Discover Cluster Specs](discover-cluster-specs). 
+## Collect a support bundle using multiple specs
+> Introduced in Troubleshoot v0.42.0
+
+You may need to collect a support bundle using the collectors and analyzers specified in multiple different specs. As of Troubleshoot `v0.42.0`, you can now pass multiple specs as arguments to the `support-bundle` CLI.
+
+Create a support bundle using multiple specs from the filesystem
+ ```shell
+kubectl support-bundle ./support-bundle-spec-1.yaml ./support-bundle-spec-2.yaml
+ ```
+
+Create a support bundle using a spec from a URL, a file, and from a Kubernetes secret
+ ```shell
+kubectl support-bundle https://raw.githubusercontent.com/replicatedhq/troubleshoot-specs/main/in-cluster/default.yaml \
+./support-bundle-spec-1.yaml \
+secret/path/to/my/spec 
+ ```
+
+## Collect a support bundle using specs discovered from the cluster
+> Introduced in Troubleshoot v0.47.0
+
+You can also use the `--load-cluster-specs` flag with the `support-bundle` CLI to collect a Support Bundle by automatically discovering Support Bundle and Redactor specs in Secrets and ConfigMaps in the cluster. For more information, see [Discover Cluster Specs](discover-cluster-specs). 

--- a/docs/source/support-bundle/supportbundle.md
+++ b/docs/source/support-bundle/supportbundle.md
@@ -48,26 +48,23 @@ apiVersion: troubleshoot.sh/v1beta2
 kind: SupportBundle
   name: supportbundle
 spec:
-  uri: https://raw.githubusercontent.com/replicatedhq/troubleshoot-specs/main/host/cluster-down.yaml
+  uri: hhttps://raw.githubusercontent.com/replicatedhq/troubleshoot-specs/main/in-cluster/default.yaml
   collectors:
     - cluster-info: {}
     - cluster-resources: {}
 ```
 
-Troubleshoot will attempt to retrieve <https://raw.githubusercontent.com/replicatedhq/troubleshoot-specs/main/host/cluster-down.yaml> and will use that spec in its entirety:
+Troubleshoot will attempt to retrieve <https://raw.githubusercontent.com/replicatedhq/troubleshoot-specs/main/in-cluster/default.yaml> and will use that spec in its entirety:
 
 ```yaml
-# Spec to run when a kURL cluster is down and in-cluster specs can't be run
 apiVersion: troubleshoot.sh/v1beta2
 kind: SupportBundle
 metadata:
-  name: cluster-down
+  name: default
 spec:
-  hostCollectors:
-    # System Info Collectors
-    - blockDevices: {}
-    - cpu: {}
-    - hostOS: {}
+  collectors:
+    - clusterInfo: {}
+    - clusterResources: {}
 ...
 ```
 
@@ -75,7 +72,7 @@ If Troubleshoot is unable to retrieve that file, or if the upstream file fails t
 
 ```yaml
 spec:
-  # uri: https://raw.githubusercontent.com/replicatedhq/troubleshoot-specs/main/host/cluster-down.yaml
+  # uri: https://raw.githubusercontent.com/replicatedhq/troubleshoot-specs/main/in-cluster/default.yaml
   collectors:
     - cluster-info: {}
     - cluster-resources: {}


### PR DESCRIPTION
* Updating documentation for both the `preflight` and `support-bundle` CLI to reflect that they both accept specifying multiple inputs for spec locations
* Updating URI documentation to use `in-cluster` specs as the example