### PR TITLE
Update logs.md & cluster-resources.md

### DIFF
--- a/docs/source/collect/cluster-resources.md
+++ b/docs/source/collect/cluster-resources.md
@@ -266,14 +266,17 @@ This file contains information about all pods, separated by namespace.
 ### `/cluster-resources/pods/logs/[namespace]/[name].json`
 
 This file contains information about all pods, separated by namespace.
+The maximum file size limit for a pods logfile is set to 5MB via the `maxBytes` limit.
 
 ### `/cluster-resources/pods/logs/[namespace]/[pod]/[container].log`
 
 This file contains logs from current containers for pods that have terminated with an error or are crash-looping.
+The maximum file size limit for a pods logfile is set to 5MB via the `maxBytes` limit.
 
 ### `/cluster-resources/pods/logs/[namespace]/[pod]/[container]-previous.log`
 
 This file contains logs from previous containers for pods that have terminated with an error or are crash-looping.
+The maximum file size limit for a pods logfile is set to 5MB via the `maxBytes` limit.
 
 ### `/cluster-resources/ingress/[namespace]/[name].json`
 

--- a/docs/source/collect/cluster-resources.md
+++ b/docs/source/collect/cluster-resources.md
@@ -266,17 +266,17 @@ This file contains information about all pods, separated by namespace.
 ### `/cluster-resources/pods/logs/[namespace]/[name].json`
 
 This file contains information about all pods, separated by namespace.
-The maximum file size limit for a pods logfile is set to 5MB.
+The maximum file size limit for a pods logfile is 5MB.
 
 ### `/cluster-resources/pods/logs/[namespace]/[pod]/[container].log`
 
 This file contains logs from current containers for pods that have terminated with an error or are crash-looping.
-The maximum file size limit for a pods logfile is set to 5MB.
+The maximum file size limit for a pods logfile is 5MB.
 
 ### `/cluster-resources/pods/logs/[namespace]/[pod]/[container]-previous.log`
 
 This file contains logs from previous containers for pods that have terminated with an error or are crash-looping.
-The maximum file size limit for a pods logfile is set to 5MB.
+The maximum file size limit for a pods logfile is 5MB.
 
 ### `/cluster-resources/ingress/[namespace]/[name].json`
 

--- a/docs/source/collect/cluster-resources.md
+++ b/docs/source/collect/cluster-resources.md
@@ -266,17 +266,17 @@ This file contains information about all pods, separated by namespace.
 ### `/cluster-resources/pods/logs/[namespace]/[name].json`
 
 This file contains information about all pods, separated by namespace.
-The maximum file size limit for a pods logfile is set to 5MB via the `maxBytes` limit.
+The maximum file size limit for a pods logfile is set to 5MB.
 
 ### `/cluster-resources/pods/logs/[namespace]/[pod]/[container].log`
 
 This file contains logs from current containers for pods that have terminated with an error or are crash-looping.
-The maximum file size limit for a pods logfile is set to 5MB via the `maxBytes` limit.
+The maximum file size limit for a pods logfile is set to 5MB.
 
 ### `/cluster-resources/pods/logs/[namespace]/[pod]/[container]-previous.log`
 
 This file contains logs from previous containers for pods that have terminated with an error or are crash-looping.
-The maximum file size limit for a pods logfile is set to 5MB via the `maxBytes` limit.
+The maximum file size limit for a pods logfile is set to 5MB.
 
 ### `/cluster-resources/ingress/[namespace]/[name].json`
 

--- a/docs/source/collect/logs.md
+++ b/docs/source/collect/logs.md
@@ -6,6 +6,9 @@ description: Including logs from pods in the collected output
 The `logs` collectors can be used to include logs from running pods.
 This collector can be included multiple times with different label selectors and/or namespaces.
 
+The maximum file size of a collected pod log, is set to 5MB as this will ensure a support bundle will not grow excessively due
+to large logfiles.
+
 ## Parameters
 
 In addition to the [shared collector properties](https://troubleshoot.sh/docs/collect/collectors/#shared-properties), the `logs` collector accepts the following parameters:

--- a/docs/source/collect/logs.md
+++ b/docs/source/collect/logs.md
@@ -65,6 +65,7 @@ The number of lines to include, starting from the newest.
 ##### `limits.maxBytes`
 The maximum file size of a collected pod log, is currently set to 5MB as this will ensure a support bundle will not grow excessively due
 to large logfiles. Neither will the logs contain information that is too old or no longer relevant.
+This value can be set in increments of bytes, e.g. a value of 5MB should be set as `5000000`.
 
 ## Example Collector Definition
 
@@ -94,6 +95,7 @@ spec:
           - db
         limits:
           maxLines: 1000
+          maxBytes: 5000000
 ```
 
 

--- a/docs/source/collect/logs.md
+++ b/docs/source/collect/logs.md
@@ -63,7 +63,8 @@ For duration string format see [time.ParseDuration](https://pkg.go.dev/time#Pars
 The number of lines to include, starting from the newest.
 
 ##### `limits.maxBytes`
-The maximum file size of a collected pod log. Defaults to `5000000`, which is 5MB.
+The maximum file size of a collected pod log. Defaults to an integer value of`5000000` bytes, which is 5MB. The value
+can only be set as an integer value for the `maxBytes` limit.
 
 ## Example Collector Definition
 

--- a/docs/source/collect/logs.md
+++ b/docs/source/collect/logs.md
@@ -62,7 +62,7 @@ For duration string format see [time.ParseDuration](https://pkg.go.dev/time#Pars
 ##### `limits.maxLines`
 The number of lines to include, starting from the newest.
 
-##### `Limits.maxBytes`
+##### `limits.maxBytes`
 The maximum file size of a collected pod log, is currently set to 5MB as this will ensure a support bundle will not grow excessively due
 to large logfiles. Neither will the logs contain information that is too old or no longer relevant.
 

--- a/docs/source/collect/logs.md
+++ b/docs/source/collect/logs.md
@@ -63,9 +63,7 @@ For duration string format see [time.ParseDuration](https://pkg.go.dev/time#Pars
 The number of lines to include, starting from the newest.
 
 ##### `limits.maxBytes`
-The maximum file size of a collected pod log, is currently set to 5MB as this will ensure a support bundle will not grow excessively due
-to large logfiles. Neither will the logs contain information that is too old or no longer relevant.
-This value can be set in increments of bytes, e.g. a value of 5MB should be set as `5000000`.
+The maximum file size of a collected pod log. Defaults to `5000000`, which is 5MB.
 
 ## Example Collector Definition
 

--- a/docs/source/collect/logs.md
+++ b/docs/source/collect/logs.md
@@ -6,9 +6,6 @@ description: Including logs from pods in the collected output
 The `logs` collectors can be used to include logs from running pods.
 This collector can be included multiple times with different label selectors and/or namespaces.
 
-The maximum file size of a collected pod log, is set to 5MB as this will ensure a support bundle will not grow excessively due
-to large logfiles.
-
 ## Parameters
 
 In addition to the [shared collector properties](https://troubleshoot.sh/docs/collect/collectors/#shared-properties), the `logs` collector accepts the following parameters:
@@ -64,6 +61,10 @@ For duration string format see [time.ParseDuration](https://pkg.go.dev/time#Pars
 
 ##### `limits.maxLines`
 The number of lines to include, starting from the newest.
+
+##### `Limits.maxBytes`
+The maximum file size of a collected pod log, is currently set to 5MB as this will ensure a support bundle will not grow excessively due
+to large logfiles. Neither will the logs contain information that is too old or no longer relevant.
 
 ## Example Collector Definition
 


### PR DESCRIPTION
In combination with the PR that fixes Troubleshoot issue 878 (https://github.com/replicatedhq/troubleshoot/issues/878) this PR handles the additional mention of the maximum logfile size.