### PR TITLE
feat(hostpreflights): udp port status

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -120,6 +120,7 @@ const themeOptions = {
               'host-collect-analyze/tcpConnect',
               'host-collect-analyze/tcpLoadBalancer',
               'host-collect-analyze/tcpPortStatus',
+              'host-collect-analyze/udpPortStatus',
               'host-collect-analyze/time',
             ],
           },

--- a/docs/source/host-collect-analyze/all.md
+++ b/docs/source/host-collect-analyze/all.md
@@ -24,6 +24,7 @@ description: A list of all available host collectors and analyzers.
 - [tcpConnect](./tcpConnect): Collects and analyzes information about the ability to connect to the the specified TCP address.
 - [tcpLoadBalancer](./tcpLoadBalancer): Collects and analyzes information about the ability to connect to the specified TCP load balancer address.
 - [tcpPortStatus](./tcpPortStatus): Collects and analyzes information about the specified TCP port.
+- [udpPortStatus](./udpPortStatus): Collects and analyzes information about the specified UDP port.
 
 ### Generated and Dynamic Data
 - [run](./run): Runs a specified command and includes the results in the collected output.

--- a/docs/source/host-collect-analyze/tcpPortStatus.md
+++ b/docs/source/host-collect-analyze/tcpPortStatus.md
@@ -42,7 +42,7 @@ If the `collectorName` field is unset, it will be named `tcpPortStatus.json`.
 Example of the resulting file:
 
 ```
-connected
+{"status":"connected","message":""}
 ```
 
 ## TCP Port Status Analyzer
@@ -71,6 +71,7 @@ spec:
   hostAnalyzers:
     - tcpPortStatus:
         checkName: "Kubernetes API TCP Port Status"
+        collectorName: kubernetes-api-tcp-port
         outcomes:
           - fail:
               when: "connection-refused"

--- a/docs/source/host-collect-analyze/tcpPortStatus.md
+++ b/docs/source/host-collect-analyze/tcpPortStatus.md
@@ -5,7 +5,7 @@ description: Collect and analyze information about the specified TCP port.
 
 ## TCP Port Status Collector
 
-To collect information about the specified TCP port on the host where the collector runs, you can use the `tcpPortStatus` collector. If an interface is specified in the collector, this preflight check looks up the IPv4 address of that interface, binds to it, and connects to the same address. If no interface is specified, the test server binds to `0.0.0.0` and attempts to connect to the first non-loopback IPv4 address found on a network interface on the host. Typically, no interface should be specified.
+To collect information about the specified TCP port on the host where the collector runs, you can use the `tcpPortStatus` collector. If an interface is specified in the collector, this preflight check looks up the IPv4 address of that interface, binds to it, and connects to the same address. If no interface is specified, the test server binds to `0.0.0.0` and attempts to connect to the first non-loopback IPv4 address found on a network interface on the host.
 
 ### Parameters
 

--- a/docs/source/host-collect-analyze/udpPortStatus.md
+++ b/docs/source/host-collect-analyze/udpPortStatus.md
@@ -5,7 +5,7 @@ description: Collect and analyze information about the specified UDP port.
 
 ## UDP Port Status Collector
 
-To collect information about the specified UDP port on the host where the collector runs, you can use the `udpPortStatus` collector. If an interface is specified in the collector, this preflight check looks up the IPv4 address of that interface and binds to it. If no interface is specified, the test server binds to `0.0.0.0`. Typically, no interface should be specified.
+To collect information about the specified UDP port on the host where the collector runs, you can use the `udpPortStatus` collector. If an interface is specified in the collector, this preflight check looks up the IPv4 address of that interface and binds to it. If no interface is specified, the test server binds to `0.0.0.0`.
 
 ### Parameters
 

--- a/docs/source/host-collect-analyze/udpPortStatus.md
+++ b/docs/source/host-collect-analyze/udpPortStatus.md
@@ -1,0 +1,83 @@
+---
+title: UDP Port Status 
+description: Collect and analyze information about the specified UDP port.
+---
+
+## UDP Port Status Collector
+
+To collect information about the specified UDP port on the host where the collector runs, you can use the `udpPortStatus` collector. If an interface is specified in the collector, this preflight check looks up the IPv4 address of that interface and binds to it. If no interface is specified, the test server binds to `0.0.0.0`. Typically, no interface should be specified.
+
+### Parameters
+
+In addition to the [shared collector properties](/collect/collectors/#shared-properties), the `udpPortStatus` collector accepts the following parameters:
+
+#### `port` (Required)
+The port number to check on the host where the collector is run.
+
+#### `interface` (Optional)
+If set, the collector uses the IP address of the of the specified interface.
+
+### Example Collector Definition
+```yaml
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: udpPortStatus
+spec:
+  hostCollectors:
+    - udpPortStatus:
+        collectorName: flannel-vxlan-udp-port
+        port: 8472
+```
+
+### Included Resources
+
+The results of the `udpPortStatus` collector are stored in the `host-collectors/udpPortStatus` directory of the support bundle.
+
+#### `[collector-name].json`
+
+If the `collectorName` field is unset, it will be named `udpPortStatus.json`.
+
+Example of the resulting file:
+
+```
+{"status":"connected","message":""}
+```
+
+## UDP Port Status Analyzer
+
+The `udpPortStatus` analyzer supports multiple outcomes:
+
+- `address-in-use`: Specified port is unavailable.
+- `connected`: Successfully bound to the port.
+- `error`: Unexpected error binding to the port.
+
+### Example Analyzer Definition
+
+```yaml
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: udpPortStatus
+spec:
+  hostCollectors:
+    - udpPortStatus:
+        collectorName: flannel-vxlan-udp-port
+        port: 8472
+  hostAnalyzers:
+    - udpPortStatus:
+        checkName: "Flannel VXLAN UDP Status"
+        collectorName: flannel-vxlan-udp-port
+        outcomes:
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 8472.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 8472 is open
+          - warn:
+              message: Unexpected port status
+```


### PR DESCRIPTION
Adds a collector to check if a UDP port is in use.

Usage example is:

```
apiVersion: troubleshoot.sh/v1beta2
kind: HostPreflight
metadata:
  name: port
spec:
  collectors:
    - udpPortStatus:
        collectorName: flannel
        port: 8472
  analyzers:
    - udpPortStatus:
        collectorName: flannel
        outcomes:
          - fail:
              when: "address-in-use"
              message: Another process was already listening on port 8472.
          - fail:
              when: "error"
              message: Unexpected port status
          - pass:
              when: "connected"
              message: Port 8472 is open
          - warn:
              message: Unexpected port status
```