### PR TITLE
adding docs for multiple exit code support in preflight

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -28,6 +28,7 @@ const themeOptions = {
               "preflight/introduction",
               "preflight/cluster-checks",
               "preflight/node-checks",
+              "preflight/exit-codes"
               "preflight/next-steps",
             ],
             "Support Bundle": [

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -28,8 +28,8 @@ const themeOptions = {
               "preflight/introduction",
               "preflight/cluster-checks",
               "preflight/node-checks",
-              "preflight/exit-codes"
               "preflight/next-steps",
+              "preflight/exit-codes"
             ],
             "Support Bundle": [
               "support-bundle/introduction",

--- a/docs/source/preflight/exit-codes.md
+++ b/docs/source/preflight/exit-codes.md
@@ -1,0 +1,16 @@
+---
+title: Exit Codes
+description: "Explains how the Preflight CLI handles exit codes"
+---
+
+When using `preflight` via the CLI, there are specific exit codes returned based on the outcomes of any checks.
+
+## Exit Codes
+
+| Code | Description |
+|------|----|
+| `0`  | All tests passed, and no errors occurred |
+| `1`  | Some error occurred (most likely not related to a specific preflight check), catch all |
+| `2`  | Invalid input (CLI options, invalid Preflight spec, etc) |
+| `3`  | At least one Preflight check resulted in a `FAIL` |
+| `4`  | No Preflight checks failed, but at least one resulted in a `WARN` |


### PR DESCRIPTION
ref https://github.com/replicatedhq/troubleshoot/issues/1131

NOTE: draft as feature not merged yet (it works, but tests aren't passing). wait on a merge of https://github.com/replicatedhq/troubleshoot/pull/1135 before merging this