### PR TITLE
59693; Clarified Password Redaction

### DIFF
--- a/docs/source/redact/passwords.md
+++ b/docs/source/redact/passwords.md
@@ -3,7 +3,9 @@ title: Passwords
 description: Automatically redacted passwords
 ---
 
-Troubleshoot automatically redacts password environment variables in JSON.
+Troubleshoot automatically redacts password environment variables in JSON for the values provided in the `regex` arrays.
+
+> **Important:** Passwords that do not match the specified regular expressions are not redacted.
 
 This redaction is equivalent to the following redact yaml:
 


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/59693/a-line-containing-the-word-password-does-not-get-redacted

This doc bug was opened by Xav. Please review.

Preview: https://deploy-preview-490--troubleshoot-sh.netlify.app/docs/redact/passwords/