### PR TITLE
Attempts to clarify what you can measure for resource

### DIFF
--- a/docs/source/analyze/node-resources.md
+++ b/docs/source/analyze/node-resources.md
@@ -4,7 +4,7 @@ description: Analyzing memory, cpu and storage available on each node
 ---
 
 The `nodeResources` analyzer is available to determine if the nodes in the cluster have sufficient resources to run an application.
-This is useful in preflight checks to avoid deploying a version that will not work, and it's useful in support bundles to collect and analyze in case the available resources of a shared cluster are being consumed by other workloads or if an autoscaling group is changing the resources available.
+This is useful in preflight checks to avoid deploying a version that will not work, and it's useful in support bundles to collect and analyze in case the available resources of a shared cluster are being reserved for cluster workloads or if an autoscaling group is changing the resources available.
 
 This analyzer's outcome `when` clause compares the condition specified with the resources present on each or all nodes.
 It's possible to create an analyzer to report on both aggregate values of all nodes in the cluster or individual values of any node in the cluster.


### PR DESCRIPTION
Rewords the first paragraph of the Node Resources analyzer documentation to clarify that you can check against what's being reserved by cluster workloads not what's being used by all other workloads.

Fix for #497 