### PR TITLE
Added DaemonSet documentation to cluster-resources.md

### DIFF
--- a/docs/source/collect/cluster-resources.md
+++ b/docs/source/collect/cluster-resources.md
@@ -235,6 +235,10 @@ This file contains information about all installed CRDs in the cluster.
 ]
 ```
 
+### `/cluster-resources/daemonsets/[namespace]/[name].json`
+
+This file contains information about all daemonsets, separated by namespace.
+
 ### `/cluster-resources/deployments/[namespace]/[name].json`
 
 This file contains information about all deployments, separated by namespace.


### PR DESCRIPTION
This change is just a few lines in cluster-resources.md to add documentation for cluster-resources collector --- adding daemonSets collection to cluster-resources collector.

This change relates to this PR: https://github.com/replicatedhq/troubleshoot/issues/1120