### PR TITLE
Adding endpoint documentation to cluster-resources.md file

### DIFF
--- a/docs/source/collect/cluster-resources.md
+++ b/docs/source/collect/cluster-resources.md
@@ -269,6 +269,10 @@ This file contains information about all statefulsets, separated by namespace.
 
 This file contains information about all services, separated by namespace.
 
+### `/cluster-resources/endpoints/[namespace]/[name].json`
+
+This file contains information about all endpoints, separated by namespace.
+
 ### `/cluster-resources/pods/[namespace]/[name].json`
 
 This file contains information about all pods, separated by namespace.


### PR DESCRIPTION
This PR is in regards to the following issue (https://github.com/replicatedhq/troubleshoot/issues/1046).

Adding verbiage to troubleshoot.sh documentation for endpoints in the cluster-resource.md file.