### PR TITLE
chore: Add indentation to metricRequests fields

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -51,6 +51,7 @@ const themeOptions = {
               'collect/exec',
               'collect/http',
               'collect/configmap',
+              'collect/custom-metrics',
               'collect/secret',
               'collect/longhorn',
               'collect/mssql',
@@ -62,7 +63,6 @@ const themeOptions = {
               'collect/run-pod',
               'collect/data',
               'collect/sysctl',
-              'collect/custom-metrics',
             ],
             "Redact": [
               "redact/index",

--- a/docs/source/collect/custom-metrics.md
+++ b/docs/source/collect/custom-metrics.md
@@ -13,13 +13,13 @@ In addition to the [shared collector properties](https://troubleshoot.sh/docs/co
 
 A list of metrics to be collected, each request is of the following format:
   - ###### `namespace`
-  for which to collect the metric values, empty for non-namespaces resources.
+  For which to collect the metric values, empty for non-namespaces resources.
 
   - ###### `objectName`
-  for which to collect metric values, all resources are considered when empty, for namespaced resources a Namespace has to be supplied regardless.
+  For which to collect metric values, all resources are considered when empty, for namespaced resources a Namespace has to be supplied regardless.
 
   - ###### `resourceMetricName`
-  name of the `MetricValueList` as per the `APIResourceList` from "custom.metrics.k8s.io/v1beta1"
+  Name of the `MetricValueList` as per the `APIResourceList` from "custom.metrics.k8s.io/v1beta1"
 
 ## Example Collector Definition
 

--- a/docs/source/collect/custom-metrics.md
+++ b/docs/source/collect/custom-metrics.md
@@ -12,14 +12,13 @@ In addition to the [shared collector properties](https://troubleshoot.sh/docs/co
 ##### `metricRequests` (Required)
 
 A list of metrics to be collected, each request is of the following format:
-
-  ###### `namespace`
+  - ###### `namespace`
   for which to collect the metric values, empty for non-namespaces resources.
 
-  ###### `objectName`
+  - ###### `objectName`
   for which to collect metric values, all resources are considered when empty, for namespaced resources a Namespace has to be supplied regardless.
 
-  ###### `resourceMetricName`
+  - ###### `resourceMetricName`
   name of the `MetricValueList` as per the `APIResourceList` from "custom.metrics.k8s.io/v1beta1"
 
 ## Example Collector Definition


### PR DESCRIPTION
It makes it clearer that these fields are part of `metricRequests` object, not root fields