### PR TITLE
feat: added spec to check cpu arch

### DIFF
--- a/docs/source/host-collect-analyze/cpu.md
+++ b/docs/source/host-collect-analyze/cpu.md
@@ -1,5 +1,5 @@
 ---
-title: CPU Description
+title: CPU
 description: Collect and analyze information about CPU features, core counts and architecture.
 ---
 

--- a/docs/source/host-collect-analyze/cpu.md
+++ b/docs/source/host-collect-analyze/cpu.md
@@ -1,7 +1,6 @@
-
 ---
-title: CPU
-description: Collect and analyze information about CPU features and core counts.
+title: CPU Description
+description: Collect and analyze information about CPU features, core counts and architecture.
 ---
 
 ## CPU Collector
@@ -120,4 +119,28 @@ spec:
               message: This server cpu suports the x86-64-v2 features
           - fail:
               message: This server does not support the x86-64-v2 features
+```
+
+Collecting and analyzing the presence of specific CPU architecture:
+
+```yaml
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: cpu
+spec:
+  hostCollectors:
+    - cpu: {}
+  hostAnalyzers:
+    - cpu:
+        checkName: "Check machine architecture"
+        outcomes:
+          - fail:
+              when: "machineArch == x86_64"
+              message: x86_64 machine architecture is not supported
+          - pass:
+              when: "machineArch == arm64"
+              message: It is recommended to use arm64 machine architecture
+          - warn:
+              message: Supported machine architecture was not detected
 ```


### PR DESCRIPTION
Story: https://app.shortcut.com/replicated/story/111542/add-support-for-cpu-architecture-to-cpu-host-collector-analyser-1584

This feature allows users to determine  the cpu architecture of machine and verify if their application supports it or not.