### PR TITLE
feat: change namespace connectivity check template

### DIFF
--- a/docs/source/host-collect-analyze/networkNamespaceConnectivity.md
+++ b/docs/source/host-collect-analyze/networkNamespaceConnectivity.md
@@ -99,8 +99,8 @@ To make the outcome message more informative, you can include certain values gat
 | Template | Description |
 |----|----|
 |`{{ .ErrorMessage }}` | Show all error messages found during the collection |
-|`{{ .FromNamespace }}` | The CIDR provided in the collector `fromCIDR` property |
-|`{{ .ToNamespace }}` | The CIDR provided in the collector `toCIDR` property |
+|`{{ .FromCIDR }}` | The CIDR provided in the collector `fromCIDR` property |
+|`{{ .ToCIDR }}` | The CIDR provided in the collector `toCIDR` property |
 
 ### Example Analyzer Definition
 


### PR DESCRIPTION
> [!IMPORTANT]  
> this change was introduced by https://github.com/replicatedhq/troubleshoot/pull/1693 so that needs to go in first.

when templating the output of the namespace connectivity check we were referring to the 'fromCIDR' as 'fromNamespace'. it makes way more sense to refer to it as 'fromCIDR' as this is how it is provided in the input for the collector.

as this is a brand new feature it is very unlikely that anyone is using it (except for the embedded cluster that still needs to be patched accordingly).

this is how the analyser was defined before (notice the templating in the `message` field):

```yaml
apiVersion: troubleshoot.sh/v1beta2
kind: HostPreflight
metadata:
    name: ec-cluster-preflight
spec:
    analyzers:
        - networkNamespaceConnectivity:
            collectorName: check-network-connectivity
            outcomes:
            - pass:
                message: "Communication between {{ .FromNamespace }} and {{ .ToNamespace }} is working"
            - fail:
                message: "{{ .ErrorMessage }}"
```

and this is how it is now:

```yaml
apiVersion: troubleshoot.sh/v1beta2
kind: HostPreflight
metadata:
    name: ec-cluster-preflight
spec:
    analyzers:
        - networkNamespaceConnectivity:
            collectorName: check-network-connectivity
            outcomes:
            - pass:
                message: "Communication between {{ .FromCIDR }} and {{ .ToCIDR }} is working"
            - fail:
                message: "{{ .ErrorMessage }}"

```