### PR TITLE
fix: js-yaml@3 to js-yaml@4 migration error

### DIFF
--- a/generate-specs.js
+++ b/generate-specs.js
@@ -58,7 +58,7 @@ fs.readdir(specDir, (err, files) => {
     let subdirSpecs = [];
     subFile.forEach(f => {
       // Load YAML file contents
-      const doc = yaml.safeLoad(fs.readFileSync(path.resolve(subDirPath + "/" + f)));
+      const doc = yaml.load(fs.readFileSync(path.resolve(subDirPath + "/" + f)));
       
       // Add all tags from spec to the tags array (will be filtered later)
       let newTags = JSON.parse(doc.metadata.annotations.tags)
@@ -105,10 +105,10 @@ fs.readdir(specDir, (err, files) => {
       // Remove annotations before setting the yaml spec
       delete doc["metadata"]["annotations"];
       if (doc.kind === "Preflight") {
-        specObj.preflightSpecYaml = yaml.safeDump(doc);
+        specObj.preflightSpecYaml = yaml.dump(doc);
       }
       if (doc.kind === "SupportBundle") {
-        specObj.supportSpecYaml = yaml.safeDump(doc);
+        specObj.supportSpecYaml = yaml.dump(doc);
       }
 
       // Add spec to specs array
@@ -143,5 +143,3 @@ fs.readdir(specDir, (err, files) => {
   });
 
 });
-
-

--- a/generate-specs/package.json
+++ b/generate-specs/package.json
@@ -3,7 +3,7 @@
   "name": "marketing",
   "version": "0.0.0",
   "dependencies": {
-    "js-yaml": "^3.13.1",
+    "js-yaml": "4.1.0",
     "lodash": "^4.17.21"
   }
 }

--- a/generate-specs/package.json
+++ b/generate-specs/package.json
@@ -3,7 +3,7 @@
   "name": "marketing",
   "version": "0.0.0",
   "dependencies": {
-    "js-yaml": "4.1.0",
+    "js-yaml": "^4.1.0",
     "lodash": "^4.17.21"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "make publish; yarn yarn:cache"
   },
   "dependencies": {
+    "js-yaml": "^4.1.0",
     "netlify-plugin-gatsby-yarn-cache": "^0.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "build": "make publish; yarn yarn:cache"
   },
   "dependencies": {
-    "js-yaml": "^4.1.0",
     "netlify-plugin-gatsby-yarn-cache": "^0.1.1"
   }
 }


### PR DESCRIPTION
Dependabot version bump of `js-yaml` is failing because

https://app.netlify.com/sites/troubleshoot-sh/deploys/67a98d408db8590008e14a64

```
4:24:08 PM:     throw new Error('Function yaml.' + from + ' is removed in js-yaml 4. ' +
4:24:08 PM:     ^
4:24:08 PM: Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.
```

 Make necessary changes according to https://github.com/nodeca/js-yaml/blob/master/migrate_v3_to_v4.md