### PR TITLE
Clarifies docs for jsonCompare analyzer

### DIFF
--- a/docs/source/analyze/json-compare.md
+++ b/docs/source/analyze/json-compare.md
@@ -11,7 +11,7 @@ The JSON compare analyzer is used to compare a JSON snippet with part or all of 
 
 **value**: (Required) JSON value to compare.
 If the value matches the collected file, the outcome that has `when` set to `"true"` will be executed.
-If a `when` expression is not specified, the `pass` outcome defaults to `"true"`.
+If a `when` expression is not specified, the `pass` outcome defaults to `"true"`. This value _must_ be specified as a multi-line YAML string and any string values must be in double quotes (see the examples).
 
 **path**: (Optional) Portion of the collected JSON file to compare against.
 The default behavior is to compare against the entire collected file.


### PR DESCRIPTION
Adds a little bit to the explanation of the `value` parameter to the JSON Compare analyzer to avoid an issue that tripped up a vendor team, @sgalsaleh , and I. This could probably be explained more clearly, but I wanted to get something out there.