### PR TITLE
chore: update docs to ensure they are in sync with the code

### DIFF
--- a/docs/analyze/cluster-pod-statuses.md
+++ b/docs/analyze/cluster-pod-statuses.md
@@ -27,7 +27,6 @@ metadata:
 spec:
   analyzers:
     - clusterPodStatuses:
-        name: unhealthy
         namespaces:
           - default
           - myapp-namespace

--- a/docs/analyze/mssql.md
+++ b/docs/analyze/mssql.md
@@ -5,7 +5,7 @@ tags: ["analyze"]
 ---
 
 
-The `MS SQL` analyzer is available to check vesion and connection status of a Microsoft SQL Server database.
+The `MS SQL` analyzer is available to check version and connection status of a Microsoft SQL Server database.
 It relies on the data collected by the [MS SQL collector](/docs/collect/mssql/).
 
 The analyzer's outcome `when` clause may be used to evaluate the database connection status or a version range to compare against the running version, and supports standard comparison operators.

--- a/docs/analyze/node-resources.md
+++ b/docs/analyze/node-resources.md
@@ -127,7 +127,7 @@ spec:
     - nodeResources:
         checkName: Must have 1 node with 16 GB (available) memory and 5 cores (on a single node) with amd64 architecture
         filters:
-          allocatableMemory: 16Gi
+          memoryAllocatable: 16Gi
           cpuArchitecture: amd64
           cpuCapacity: "5"
         outcomes:
@@ -163,7 +163,7 @@ Troubleshoot allows users to analyze nodes that match one or more labels. For ex
     - nodeResources:
         checkName: Must have Mongo running
         filters:
-          allocatableMemory: 16Gi
+          memoryAllocatable: 16Gi
           cpuCapacity: "5"
           selector:
             matchLabel:

--- a/docs/analyze/postgresql.md
+++ b/docs/analyze/postgresql.md
@@ -5,7 +5,7 @@ tags: ["analyze"]
 ---
 
 
-The `PostgreSQL` analyzer is available to check vesion and connection status of a PostgreSQL database. 
+The `PostgreSQL` analyzer is available to check version and connection status of a PostgreSQL database. 
 It relies on the data collected by the [PostgreSQL collector](/docs/collect/postgresql/).
 
 The analyzer's outcome `when` clause may be used to evaluate the database connection status or a semver range to compare against the running version, and supports standard comparison operators.

--- a/docs/analyze/redis.md
+++ b/docs/analyze/redis.md
@@ -5,7 +5,7 @@ tags: ["analyze"]
 ---
 
 
-The `Redis` analyzer is available to check vesion and connection status of a Redis database.
+The `Redis` analyzer is available to check version and connection status of a Redis database.
 It relies on the data collected by the [Redis collector](/docs/collect/redis/).
 
 The analyzer's outcome `when` clause may be used to evaluate the database connection status or a semver range to compare against the running version, and supports standard comparison operators.

--- a/docs/analyze/storage-class.md
+++ b/docs/analyze/storage-class.md
@@ -57,7 +57,7 @@ spec:
 Defaults for storageClass analyzer are:
   - ```checkName``` = 'Default Storage Class'
   - Fail Message = 'No default storage class found'
-  - Pass Message = 'Default Storge Class found'
+  - Pass Message = 'Default Storage Class found'
 
 ```yaml
 apiVersion: troubleshoot.sh/v1beta2

--- a/docs/collect/ceph.md
+++ b/docs/collect/ceph.md
@@ -37,15 +37,23 @@ spec:
 
 The output of command `ceph status -f json-pretty`.
 
+### `/ceph/([collector-name]/)status-txt.txt`
+
+The output of command `ceph status` (plain text format).
+
 ### `/ceph/([collector-name]/)fs.json`
 
-The output of command `ceph fs -f json-pretty`.
+The output of command `ceph fs status -f json-pretty`.
+
+### `/ceph/([collector-name]/)fs-txt.txt`
+
+The output of command `ceph fs status` (plain text format).
 
 ### `/ceph/([collector-name]/)fs-ls.json`
 
 The output of command `ceph fs ls -f json-pretty`.
 
-### `/ceph/([collector-name]/)osd-status.txt`
+### `/ceph/([collector-name]/)osd-status.json`
 
 The output of command `ceph osd status -f json-pretty`.
 
@@ -65,10 +73,26 @@ The output of command `ceph health detail -f json-pretty`.
 
 The output of command `ceph auth ls -f json-pretty`.
 
+### `/ceph/([collector-name]/)rgw-stats.json`
+
+The output of command `radosgw-admin bucket stats --rgw-cache-enabled=false`.
+
+### `/ceph/([collector-name]/)rbd-du-txt.txt`
+
+The output of command `rbd du --pool=replicapool`.
+
 ### `/ceph/([collector-name]/)df.json`
 
 The output of command `ceph df -f json-pretty`.
 
-### `/ceph/([collector-name]/)rbd-du-txt.txt`
+### `/ceph/([collector-name]/)df-txt.txt`
 
-The output of command `ceph rbd du --pool=replicapool`.
+The output of command `ceph df` (plain text format).
+
+### `/ceph/([collector-name]/)osd-df.json`
+
+The output of command `ceph osd df -f json-pretty`.
+
+### `/ceph/([collector-name]/)osd-df-txt.txt`
+
+The output of command `ceph osd df` (plain text format).

--- a/docs/collect/copy-from-host.md
+++ b/docs/collect/copy-from-host.md
@@ -99,6 +99,10 @@ spec:
 
 When this collector is executed, it will include the following files in a support bundle:
 
-### `/[name or hostPath]/[node name]/archive.tar`
+### `/[name or hostPath]/[node-name]/archive.tar`
 
-This will contain tar archives of the directory or file from all nodes.
+When `extractArchive` is `false` (default), this will contain tar archives of the directory or file from all nodes.
+
+### `/[name or hostPath]/[node-name]/[extracted-files]`
+
+When `extractArchive` is set to `true`, individual files are extracted and placed at this path instead of creating an archive.

--- a/docs/collect/copy.md
+++ b/docs/collect/copy.md
@@ -65,7 +65,8 @@ spec:
 When this collector is executed, it will include the following files in a support bundle:
 
 
-### `/[namespace]/[pod-name]/[container-name]/[path]`
+### `/[name]/[namespace]/[pod-name]/[container-name]/[path]`
 
+When a `name` is specified in the collector, it is used as a prefix to the output path. If `name` is not specified, the path starts directly with the namespace.
 
-This will contain the pod's folder or file specified in the collector
+This will contain the pod's folder or file specified in the collector.

--- a/docs/collect/custom-metrics.md
+++ b/docs/collect/custom-metrics.md
@@ -52,7 +52,7 @@ When this collector is executed, it will include the following files in a suppor
    |_ <metric_name> # raw metric name truncated from the resource name as per custom.metrics.k8s.io/v1beta1/ e.g. "namespaces/cpu_usage" would result in metric_name "cpu_usage"
       |_ <namespace>.json or <non_namespaced_object>.json # values for namespaced resources metrics are saved together in a file named after the namespace. For non-namespaced resources, each resource has their metric values in a separate file named after the resource. 
 ```
-### `/metrics/Pod/default/cpu_usage.json`
+### `/metrics/Pod/cpu_usage/default.json`
 
 ```json
 [
@@ -77,7 +77,7 @@ When this collector is executed, it will include the following files in a suppor
 ]
 ```
 
-### `/metrics/Service/my-namespace/node_memory_HugePages_Free.json`
+### `/metrics/Service/node_memory_HugePages_Free/my-namespace.json`
 
 ```json
 [
@@ -102,7 +102,7 @@ When this collector is executed, it will include the following files in a suppor
 ]
 ```
 
-### `/metrics/Node/node_cpu_guest.json`
+### `/metrics/Node/node_cpu_guest/node1.json`
 
 ```json
 [

--- a/docs/collect/exec.md
+++ b/docs/collect/exec.md
@@ -27,7 +27,8 @@ The namespace to look for the pod selector in.
 If not specified, it will assume the "current" namespace that the kubectl context is set to.
 
 ##### `containerName` (Optional)
-The name of the container in which to execute the command. if not specified, the first container in the pod will be used.
+The name of the container in which to execute the command. If not specified, the first container in the pod will be used.
+This field is used only for container selection — it does not affect the output file naming. To control output file names, use `collectorName`.
 
 ##### `command` (Required)
 An array of strings containing the command to execute in the pod.
@@ -61,7 +62,9 @@ spec:
 
 ## Included Resources
 
-When this collector is executed, it will include the following file in a support bundle:
+When this collector is executed, it will include the following file in a support bundle.
+The `[collector-name]` in the paths below refers to the `collectorName` field (not `name` or `containerName`).
+The `name` field is used as the top-level directory prefix.
 
 ### `/[name]/[namespace]/[pod-name]/[collector-name]-stdout.txt`
 

--- a/docs/collect/http.md
+++ b/docs/collect/http.md
@@ -5,7 +5,10 @@ tags: ["collect"]
 ---
 
 
-The `http` collector can be used to execute http requests from inside the cluster.
+The `http` collector can be used to execute HTTP requests at collection time.
+The collector makes requests from the network context of the process running the support bundle CLI.
+If the CLI runs inside a pod, requests use cluster networking (e.g. `*.svc.cluster.local` DNS resolves).
+If the CLI runs outside the cluster (CI runners, local machines), requests use the host network and in-cluster DNS names will not resolve.
 The response code and response body will be included in the collected data.
 The http collector can be specified multiple times in a collector spec.
 

--- a/docs/collect/http.md
+++ b/docs/collect/http.md
@@ -53,6 +53,11 @@ In addition to the [shared collector properties](/docs/collect/collectors/#share
   When present, the timeout for the request.
   Expressed as a string duration, such as `30s`, `5m`, `1h`.
 
+- ##### `name` string (Optional)
+
+  When present, used as a directory prefix for the output file path in the support bundle.
+  For example, if `name` is set to `my-app`, the output file will be saved at `my-app/[collector-name].json`.
+
 ## Example Collector Definition
 
 ### GET
@@ -108,11 +113,9 @@ spec:
 
 ## Included resources
 
-Result of each collector will be stored in the root directory of the support bundle.
+### `[name]/[collector-name].json`
 
-### `[collector-name].json`
-
-If the `collectorName` field is unset it will be named `result.json`.
+The output file is stored at `[name]/[collector-name].json` in the support bundle. If the `name` field is not set, the file is stored in the root directory of the bundle. If the `collectorName` field is unset, the file will be named `result.json`.
 
 Response received from the server will be stored in the `"response"` key of the resulting JSON file:
 

--- a/docs/collect/logs.md
+++ b/docs/collect/logs.md
@@ -50,7 +50,7 @@ Name can contain slashes to create a path in the support bundle.
 ##### `containerNames` (Optional)
 ContainerNames is an array of container names.
 If specified, logs for each container in the list will be collected.
-This can be omitted for pods with only one container.
+If omitted, logs for **all** containers in the pod are collected, including init containers.
 
 ##### `limits` (Optional)
 Provided to limit the size of the logs.
@@ -66,8 +66,11 @@ For duration string format see [time.ParseDuration](https://pkg.go.dev/time#Pars
 The number of lines to include, starting from the newest.
 
 ##### `limits.maxBytes`
-The maximum file size of a collected pod log. Defaults to an integer value of`5000000` bytes, which is 5MB. The value
+The maximum file size of a collected pod log. Defaults to an integer value of `5000000` bytes, which is 5MB. The value
 can only be set as an integer value for the `maxBytes` limit.
+
+##### `timestamps` (Optional)
+When set to `true`, each log line will be prefixed with an RFC3339 timestamp from the Kubernetes API. Defaults to `false`.
 
 ## Example Collector Definition
 
@@ -105,11 +108,13 @@ spec:
 
 When this collector is executed, it will include the following files in a support bundle:
 
-### `/[name]/[pod-name]/[container-name].log`
+### `/cluster-resources/pods/logs/[namespace]/[pod-name]/[container-name].log`
+
+The actual log files are stored under `cluster-resources/pods/logs/`. A symlink is created at `/[name]/[pod-name]/[container-name].log` pointing to the actual file, so logs can be accessed via either path.
 
 This will be created for each pod that matches the selector.
 
-If any errors are encounted, the following file will be created:
+If any errors are encountered, the following file will be created:
 
 ### `/[name]/[pod-name]/[container-name]-errors.json`
 

--- a/docs/collect/run-pod.md
+++ b/docs/collect/run-pod.md
@@ -135,3 +135,11 @@ When this collector is executed, it will include the following files in a suppor
 ### `/[collector-name]/[collector-name].log`
 
 This will contain the pod output (up to 10000 lines).
+
+### `/[collector-name]/[collector-name].json`
+
+This will contain the pod status details in JSON format.
+
+### `/[collector-name]/[collector-name]-events.json`
+
+This will contain Kubernetes events related to the pod in JSON format.

--- a/docs/collect/sysctl.md
+++ b/docs/collect/sysctl.md
@@ -5,7 +5,7 @@ tags: ["collect"]
 ---
 
 
-The `sysctl` collector reads kernel parameter settings from /proc/sys/net/ipv4 and /proc/sys/net/bridge on all nodes.
+The `sysctl` collector reads kernel parameter settings from /proc/sys/net/ipv4, /proc/sys/net/bridge, and /proc/sys/vm on all nodes.
 This collector schedules a pod on every node using the specified image.
 
 ## Parameters

--- a/docs/host-collect-analyze/blockDevices.md
+++ b/docs/host-collect-analyze/blockDevices.md
@@ -84,6 +84,9 @@ Includes unmounted partitions in the analysis. Disabled by default.
 #### `minimumAcceptableSize` (Optional)
 The minimum acceptable size to filter the available block devices during analysis. Disabled by default.
 
+#### `additionalDeviceTypes` (Optional)
+A list of extra lsblk TYPE values (e.g. `loop`, `lvm`) that should count toward outcomes, in addition to whole disks and (when `includeUnmountedPartitions` is set) partitions. By default, only `disk` type devices are counted. Types in this list are eligible regardless of the `includeUnmountedPartitions` setting.
+
 ### Example Analyzer Definition
 
 ```yaml
@@ -98,6 +101,8 @@ spec:
     - blockDevices:
         includeUnmountedPartitions: true
         minimumAcceptableSize: 10737418240 # 1024 ^ 3 * 10, 10GiB
+        additionalDeviceTypes:
+          - lvm
         outcomes:
         - pass:
             when: ".* == 1"

--- a/docs/host-collect-analyze/certificate.md
+++ b/docs/host-collect-analyze/certificate.md
@@ -14,10 +14,10 @@ To collect information about a certificate key pair on the host, use the `certif
 In addition to the [shared collector properties](/docs/collect/collectors/#shared-properties), the `certificate` collector accepts the following parameters:
 
 #### `certificatePath` (Required)
-Includes unmounted partitions in the analysis. Disabled by default.
+The path to the TLS certificate file on the host (e.g. `/etc/ssl/corp.crt`).
 
 #### `keyPath` (Required)
-The minimum acceptable size to filter the available block devices during the analysis. Disabled by default.
+The path to the private key file on the host (e.g. `/etc/ssl/corp.key`).
 
 ### Example Collector Definition
 
@@ -35,7 +35,7 @@ spec:
 
 ### Included Resources
 
-The results of the `blockDevices` collector are stored in the `host-collectors/certificate` directory of the support bundle.
+The results of the `certificate` collector are stored in the `host-collectors/certificate` directory of the support bundle.
 
 #### `[collector-name].json`
 
@@ -49,14 +49,14 @@ key-pair-valid
 
 ## TLS Certificate Analyzer
 
-The `diskUsage` analyzer supports multiple outcomes. For example:
+The `certificate` analyzer supports multiple outcomes. For example:
 
 - `key-pair-missing`: Key pair fails do not exist.
 - `key-pair-switched`: PEM inputs may have been switched.
 - `key-pair-encrypted`: Key pair is encrypted, could not read the key.
 - `key-pair-mismatch`: Private key does not match the public key.
 - `key-pair-invalid`: Key pair is invalid.
-- `key-pair-valid`: Key pair is invalid.
+- `key-pair-valid`: Key pair is valid.
 
 ### Example Analyzer Definition
 

--- a/docs/host-collect-analyze/filesystemPerformance.md
+++ b/docs/host-collect-analyze/filesystemPerformance.md
@@ -46,10 +46,10 @@ Specifies how long to run the background IOPS read and write workloads prior to 
 #### `backgroundWriteIOPS` (Optional)
 Specifies the target write IOPS to run while benchmarking. This is a limit and there is no guarantee it will be reached. This is the total IOPS for all background write jobs.
 
-#### `backgroundWriteIOPS` (Optional)
+#### `backgroundReadIOPS` (Optional)
 Specifies the target read IOPS to run while benchmarking. This is a limit and there is no guarantee it will be reached. This is the total IOPS for all background read jobs.
 
-#### `backgroundWriteIOPS` (Optional)
+#### `backgroundWriteIOPSJobs` (Optional)
 Specifies the number of threads to use for background write IOPS. This value should be set high enough to reach the target specified in `backgroundWriteIOPS`. For example, if `backgroundWriteIOPS` is 100 and write latency is 10ms, then a single job would barely be able to reach 100 IOPS, so this value should be at least 2.
 
 #### `backgroundReadIOPSJobs` (Optional)

--- a/docs/host-collect-analyze/networkNamespaceConnectivity.md
+++ b/docs/host-collect-analyze/networkNamespaceConnectivity.md
@@ -57,11 +57,11 @@ Example of the resulting JSON file:
 
 ```json
 {
-  "from_namespace": "10.0.0.0/24",
-  "to_namespace": "10.0.1.0/24",
+  "from_cidr": "10.0.0.0/24",
+  "to_cidr": "10.0.1.0/24",
   "errors": {
-    "from_namespace_creation": "",
-    "to_namespace_creation": "",
+    "from_cidr_creation": "",
+    "to_cidr_creation": "",
     "udp_client": "error reading from udp socket: read udp 10.0.0.1:60767->10.0.1.1:8888: i/o timeout",
     "udp_server": "error reading from udp socket: read udp 10.0.1.1:8888: i/o timeout",
     "tcp_client": "error dialing tcp: dial tcp 10.0.1.1:8888: i/o timeout",
@@ -124,7 +124,7 @@ spec:
       collectorName: check-network-connectivity
       outcomes:
       - pass:
-          message: "Communication between {{ .FromNamespace }} and {{ .ToNamespace }} is working"
+          message: "Communication between {{ .FromCIDR }} and {{ .ToCIDR }} is working"
       - fail:
           message: "{{ .ErrorMessage }}"
 ```

--- a/docs/redact/api-tokens.md
+++ b/docs/redact/api-tokens.md
@@ -19,7 +19,7 @@ spec:
   - name: Redact values for environment variables with names beginning with 'token'
     removals:
       regex:
-      - redactor: '(?i)(\\\"name\\\":\\\"[^\"]*token[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\"'
+      - redactor: '(?i)(\\\"name\\\":\\\"[^\"]*token[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")' 
   - name: Redact values that look like API tokens in multiline JSON
     removals:
       regex:

--- a/docs/redact/database-connection-strings.md
+++ b/docs/redact/database-connection-strings.md
@@ -23,7 +23,7 @@ spec:
   - name: Redact values for environment variables with names beginning with 'database'
     removals:
       regex:
-      - redactor: '(?i)(\\\"name\\\":\\\"[^\"]*database[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\"'
+      - redactor: '(?i)(\\\"name\\\":\\\"[^\"]*database[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")' 
   - name: Redact 'Data Source' values commonly found in database connection strings
     removals:
       regex:

--- a/docs/redact/usernames.md
+++ b/docs/redact/usernames.md
@@ -19,7 +19,7 @@ spec:
   - name: Redact values for environment variables with names beginning with 'user'
     removals:
       regex:
-      - redactor: '(?i)(\\\"name\\\":\\\"[^\"]*user[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\"'
+      - redactor: '(?i)(\\\"name\\\":\\\"[^\"]*user[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")' 
   - name: Redact usernames in multiline JSON
     removals:
       regex:


### PR DESCRIPTION
## Summary

  Systematic audit of all collector, redactor, and analyzer documentation against the Go source code in [replicatedhq/troubleshoot](https://github.com/replicatedhq/troubleshoot). Every doc
  page was compared against its corresponding implementation to find behavior mismatches — wrong output paths, missing parameters, incorrect field names, and copy-paste errors.

  This addresses the root cause identified in SC-136406: vendors burn CI iterations and read source code because the docs don't match actual behavior.

  ### Collectors (10 fixes)
  - **http** — Clarified that network context depends on where the CLI runs (not always "from inside the cluster"); documented `name` field as directory prefix for output path
  - **exec** — Clarified that `collectorName` drives output file naming, not `containerName`; `containerName` is for container selection only
  - **logs** — Documented actual file path (`cluster-resources/pods/logs/...`) with symlinks from `{name}/...`; added undocumented `timestamps` parameter; documented init container collection
   when `containerNames` is omitted
  - **copy** — Documented `name` field as output path prefix
  - **copy-from-host** — Documented conditional `extractArchive` behavior (archive.tar vs extracted files)
  - **run-pod** — Added 2 undocumented output files (`.json` pod status, `-events.json` pod events)
  - **sysctl** — Added missing `/proc/sys/vm` to collected paths
  - **ceph** — Added 6 missing output files; fixed wrong file extension on `osd-status` (.json not .txt); corrected command names
  - **custom-metrics** — Fixed swapped path components in output examples (`metrics/<Kind>/<metric>/<ns>.json` not `metrics/<Kind>/<ns>/<metric>.json`)

  ### Redactors (1 fix)
  - **api-tokens, usernames, database-connection-strings** — Fixed truncated regex patterns (missing closing `)` in single-line JSON env var patterns)

  ### Analyzers (4 fixes)
  - **node-resources** — Fixed wrong filter field name: `allocatableMemory` → `memoryAllocatable`
  - **storage-class** — Fixed "Storge" → "Storage" typo
  - **postgresql, redis, mssql** — Fixed "vesion" → "version" typo
  - **cluster-pod-statuses** — Removed invalid `name` parameter from example

  ### Host Collectors/Analyzers (4 fixes)
  - **blockDevices** — Documented `additionalDeviceTypes` parameter (from replicatedhq/troubleshoot#2002)
  - **certificate** — Fixed copy-pasted blockDevices descriptions, wrong collector name references, contradictory outcome text
  - **filesystemPerformance** — Fixed 3 parameters all named `backgroundWriteIOPS` → correct names (`backgroundReadIOPS`, `backgroundWriteIOPSJobs`)
  - **networkNamespaceConnectivity** — Fixed JSON field names (`from_cidr`/`to_cidr` not `from_namespace`/`to_namespace`) and template variables

Issue: https://app.shortcut.com/replicated/story/136406/theme-4-troubleshoot-collector-behavior-doesn-t-match-docs

  ## Test plan
  - [ ] Verify site builds without errors (`npm run build`)
  - [ ] Spot-check a few corrected output paths against an actual support bundle
  - [ ] Review `node-resources` filter field name fix against a live preflight