### PR TITLE
docs: run connectivity collectors in-cluster (collect subcommands)

### DIFF
--- a/docs/collect/clickhouse.md
+++ b/docs/collect/clickhouse.md
@@ -167,7 +167,7 @@ analyzers:
       checkName: ClickHouse reachable
       collectorName: clickhouse-check
       fileName: "*.log"
-      regex: '"isConnected":true'
+      regex: '"isConnected": *true'
       outcomes:
         - pass:
             when: "true"

--- a/docs/collect/clickhouse.md
+++ b/docs/collect/clickhouse.md
@@ -5,6 +5,12 @@ tags: ["collect"]
 ---
 
 The data collector will validate and add information about a ClickHouse server to a support bundle.
+The collector uses the network of the process running the support bundle CLI.
+
+- **Inside a pod:** requests use cluster networking, and in-cluster DNS (e.g. `*.svc.cluster.local`) resolves.
+- **Outside the cluster (CI runners, local machines):** requests use the host network, and in-cluster DNS names will not resolve.
+
+To check connectivity to an in-cluster service, run the check from inside the cluster. See [Run this check inside the cluster](#run-this-check-inside-the-cluster) below.
 
 ## Parameters
 
@@ -143,7 +149,7 @@ spec:
 
 ## Run this check inside the cluster
 
-By default the `clickhouse` collector connects from the machine running the CLI, so it tests connectivity from there rather than from inside the cluster. To run the connection check from _inside_ the cluster, run it as a Pod using the [`runPod`](/docs/collect/run-pod) collector with the Troubleshoot image (`replicated/troubleshoot`, v0.131.0 or later) and the `collect clickhouse` subcommand. The Pod runs the collector from within the cluster and prints the same result JSON to its logs, which you evaluate with [`textAnalyze`](/docs/analyze/regex):
+By default the `clickhouse` collector uses the network of the process running the CLI (see above). To run the connection check from _inside_ the cluster, run it as a Pod using the [`runPod`](/docs/collect/run-pod) collector with the Troubleshoot image (`proxy.replicated.com/library/troubleshoot`, v0.131.0 or later) and the `collect clickhouse` subcommand. The Pod runs the collector from within the cluster and prints the same result JSON to its logs, which you evaluate with [`textAnalyze`](/docs/analyze/regex):
 
 ```yaml
 collectors:
@@ -154,7 +160,7 @@ collectors:
         restartPolicy: Never
         containers:
           - name: check
-            image: replicated/troubleshoot:v0.131.0
+            image: proxy.replicated.com/library/troubleshoot:v0.131.0
             command: ["collect", "clickhouse", "--uri", "clickhouse://user:pass@my-clickhouse.default.svc.cluster.local:9000/default"]
 analyzers:
   - textAnalyze:

--- a/docs/collect/clickhouse.md
+++ b/docs/collect/clickhouse.md
@@ -141,6 +141,38 @@ spec:
           skipVerify: true
 ```
 
+## Run this check inside the cluster
+
+By default the `clickhouse` collector connects from the machine running the CLI, so it tests connectivity from there rather than from inside the cluster. To run the connection check from _inside_ the cluster, run it as a Pod using the [`runPod`](/docs/collect/run-pod) collector with the Troubleshoot image (`replicated/troubleshoot`, v0.131.0 or later) and the `collect clickhouse` subcommand. The Pod runs the collector from within the cluster and prints the same result JSON to its logs, which you evaluate with [`textAnalyze`](/docs/analyze/regex):
+
+```yaml
+collectors:
+  - runPod:
+      name: clickhouse-check
+      namespace: default
+      podSpec:
+        restartPolicy: Never
+        containers:
+          - name: check
+            image: replicated/troubleshoot:v0.131.0
+            command: ["collect", "clickhouse", "--uri", "clickhouse://user:pass@my-clickhouse.default.svc.cluster.local:9000/default"]
+analyzers:
+  - textAnalyze:
+      checkName: ClickHouse reachable
+      collectorName: clickhouse-check
+      fileName: "*.log"
+      regex: '"isConnected":true'
+      outcomes:
+        - pass:
+            when: "true"
+            message: "Connected to ClickHouse from inside the cluster."
+        - fail:
+            when: "false"
+            message: "Could not connect to ClickHouse from inside the cluster."
+```
+
+The `collect clickhouse` subcommand accepts `--uri` (required, a clickhouse-go DSN) plus the TLS flags `--tls-cacert`, `--tls-client-cert`, `--tls-client-key`, `--tls-skip-verify`, `--tls-secret-name`, and `--tls-secret-namespace`, which map to the `uri` and `tls` parameters above.
+
 ## Included resources
 
 A single JSON file will be added to the support bundle, in the path `/clickhouse/[collector-name].json`:

--- a/docs/collect/http.md
+++ b/docs/collect/http.md
@@ -134,7 +134,7 @@ analyzers:
       checkName: HTTP endpoint reachable
       collectorName: http-check
       fileName: "*.log"
-      regex: '"status": 200'
+      regex: '"status": *200'
       outcomes:
         - pass:
             when: "true"

--- a/docs/collect/http.md
+++ b/docs/collect/http.md
@@ -11,7 +11,7 @@ The collector uses the network of the process running the support bundle CLI.
 - **Inside a pod:** requests use cluster networking, and in-cluster DNS (e.g. `*.svc.cluster.local`) resolves.
 - **Outside the cluster (CI runners, local machines):** requests use the host network, and in-cluster DNS names will not resolve.
 
-To check connectivity to an in-cluster service, run the CLI inside a pod.
+To check connectivity to an in-cluster service, run the check from inside the cluster. See [Run this check inside the cluster](#run-this-check-inside-the-cluster) below.
 The response code and response body will be included in the collected data.
 The http collector can be specified multiple times in a collector spec.
 

--- a/docs/collect/http.md
+++ b/docs/collect/http.md
@@ -114,6 +114,38 @@ spec:
             Content-Type: 'application/json'
 ```
 
+## Run this check inside the cluster
+
+By default the `http` collector uses the network of the process running the CLI (see above). To run the request from _inside_ the cluster — for example, to verify that an in-cluster Service is reachable — run the collector as a Pod using the [`runPod`](/docs/collect/run-pod) collector with the Troubleshoot image (`replicated/troubleshoot`, v0.131.0 or later) and the `collect http` subcommand. The Pod runs the collector from within the cluster and prints the same result JSON to its logs, which you evaluate with [`textAnalyze`](/docs/analyze/regex):
+
+```yaml
+collectors:
+  - runPod:
+      name: http-check
+      namespace: default
+      podSpec:
+        restartPolicy: Never
+        containers:
+          - name: check
+            image: replicated/troubleshoot:v0.131.0
+            command: ["collect", "http", "--url", "http://my-service.default.svc.cluster.local:8080/healthz"]
+analyzers:
+  - textAnalyze:
+      checkName: HTTP endpoint reachable
+      collectorName: http-check
+      fileName: "*.log"
+      regex: '"status": 200'
+      outcomes:
+        - pass:
+            when: "true"
+            message: "The endpoint returned 200 from inside the cluster."
+        - fail:
+            when: "false"
+            message: "The endpoint was not reachable from inside the cluster."
+```
+
+The `collect http` subcommand accepts `--url` (required), `--method` (`GET`, `POST`, or `PUT`), `--header key=value` (repeatable), `--body`, `--timeout`, `--proxy`, `--insecure-skip-verify`, and `--tls-cacert`.
+
 ## Included resources
 
 ### `[name]/[collector-name].json`

--- a/docs/collect/http.md
+++ b/docs/collect/http.md
@@ -116,7 +116,7 @@ spec:
 
 ## Run this check inside the cluster
 
-By default the `http` collector uses the network of the process running the CLI (see above). To run the request from _inside_ the cluster — for example, to verify that an in-cluster Service is reachable — run the collector as a Pod using the [`runPod`](/docs/collect/run-pod) collector with the Troubleshoot image (`replicated/troubleshoot`, v0.131.0 or later) and the `collect http` subcommand. The Pod runs the collector from within the cluster and prints the same result JSON to its logs, which you evaluate with [`textAnalyze`](/docs/analyze/regex):
+By default the `http` collector uses the network of the process running the CLI (see above). To run the request from _inside_ the cluster — for example, to verify that an in-cluster Service is reachable — run the collector as a Pod using the [`runPod`](/docs/collect/run-pod) collector with the Troubleshoot image (`proxy.replicated.com/library/troubleshoot`, v0.131.0 or later) and the `collect http` subcommand. The Pod runs the collector from within the cluster and prints the same result JSON to its logs, which you evaluate with [`textAnalyze`](/docs/analyze/regex):
 
 ```yaml
 collectors:
@@ -127,7 +127,7 @@ collectors:
         restartPolicy: Never
         containers:
           - name: check
-            image: replicated/troubleshoot:v0.131.0
+            image: proxy.replicated.com/library/troubleshoot:v0.131.0
             command: ["collect", "http", "--url", "http://my-service.default.svc.cluster.local:8080/healthz"]
 analyzers:
   - textAnalyze:

--- a/docs/collect/mssql.md
+++ b/docs/collect/mssql.md
@@ -60,7 +60,7 @@ analyzers:
       checkName: SQL Server reachable
       collectorName: mssql-check
       fileName: "*.log"
-      regex: '"isConnected":true'
+      regex: '"isConnected": *true'
       outcomes:
         - pass:
             when: "true"

--- a/docs/collect/mssql.md
+++ b/docs/collect/mssql.md
@@ -11,7 +11,7 @@ The collector uses the network of the process running the support bundle CLI.
 - **Inside a pod:** requests use cluster networking, and in-cluster DNS (e.g. `*.svc.cluster.local`) resolves.
 - **Outside the cluster (CI runners, local machines):** requests use the host network, and in-cluster DNS names will not resolve.
 
-To check connectivity to an in-cluster service, run the CLI inside a pod.
+To check connectivity to an in-cluster service, run the check from inside the cluster. See [Run this check inside the cluster](#run-this-check-inside-the-cluster) below.
 
 ## Parameters
 
@@ -42,7 +42,7 @@ spec:
 
 ## Run this check inside the cluster
 
-By default the `mssql` collector connects from the machine running the CLI, so it tests connectivity from there rather than from inside the cluster. To run the connection check from _inside_ the cluster, run it as a Pod using the [`runPod`](/docs/collect/run-pod) collector with the Troubleshoot image (`replicated/troubleshoot`, v0.131.0 or later) and the `collect mssql` subcommand. The Pod runs the collector from within the cluster and prints the same result JSON to its logs, which you evaluate with [`textAnalyze`](/docs/analyze/regex):
+By default the `mssql` collector uses the network of the process running the CLI (see above). To run the connection check from _inside_ the cluster, run it as a Pod using the [`runPod`](/docs/collect/run-pod) collector with the Troubleshoot image (`proxy.replicated.com/library/troubleshoot`, v0.131.0 or later) and the `collect mssql` subcommand. The Pod runs the collector from within the cluster and prints the same result JSON to its logs, which you evaluate with [`textAnalyze`](/docs/analyze/regex):
 
 ```yaml
 collectors:
@@ -53,7 +53,7 @@ collectors:
         restartPolicy: Never
         containers:
           - name: check
-            image: replicated/troubleshoot:v0.131.0
+            image: proxy.replicated.com/library/troubleshoot:v0.131.0
             command: ["collect", "mssql", "--uri", "sqlserver://user:pass@my-db.default.svc.cluster.local:1433"]
 analyzers:
   - textAnalyze:

--- a/docs/collect/mssql.md
+++ b/docs/collect/mssql.md
@@ -40,6 +40,38 @@ spec:
         uri: sqlserver://username:password@hostname:1433/defaultdb
 ```
 
+## Run this check inside the cluster
+
+By default the `mssql` collector connects from the machine running the CLI, so it tests connectivity from there rather than from inside the cluster. To run the connection check from _inside_ the cluster, run it as a Pod using the [`runPod`](/docs/collect/run-pod) collector with the Troubleshoot image (`replicated/troubleshoot`, v0.131.0 or later) and the `collect mssql` subcommand. The Pod runs the collector from within the cluster and prints the same result JSON to its logs, which you evaluate with [`textAnalyze`](/docs/analyze/regex):
+
+```yaml
+collectors:
+  - runPod:
+      name: mssql-check
+      namespace: default
+      podSpec:
+        restartPolicy: Never
+        containers:
+          - name: check
+            image: replicated/troubleshoot:v0.131.0
+            command: ["collect", "mssql", "--uri", "sqlserver://user:pass@my-db.default.svc.cluster.local:1433"]
+analyzers:
+  - textAnalyze:
+      checkName: SQL Server reachable
+      collectorName: mssql-check
+      fileName: "*.log"
+      regex: '"isConnected":true'
+      outcomes:
+        - pass:
+            when: "true"
+            message: "Connected to SQL Server from inside the cluster."
+        - fail:
+            when: "false"
+            message: "Could not connect to SQL Server from inside the cluster."
+```
+
+The `collect mssql` subcommand accepts only `--uri` (required). TLS is configured through the connection URI query parameters (for example, `?encrypt=true`).
+
 ## Included resources
 
 A single JSON file will be added to the support bundle, in the path `/mssql/[collector-name].json`:

--- a/docs/collect/mysql.md
+++ b/docs/collect/mysql.md
@@ -71,7 +71,7 @@ analyzers:
       checkName: MySQL reachable
       collectorName: mysql-check
       fileName: "*.log"
-      regex: '"isConnected":true'
+      regex: '"isConnected": *true'
       outcomes:
         - pass:
             when: "true"

--- a/docs/collect/mysql.md
+++ b/docs/collect/mysql.md
@@ -11,7 +11,7 @@ The collector uses the network of the process running the support bundle CLI.
 - **Inside a pod:** requests use cluster networking, and in-cluster DNS (e.g. `*.svc.cluster.local`) resolves.
 - **Outside the cluster (CI runners, local machines):** requests use the host network, and in-cluster DNS names will not resolve.
 
-To check connectivity to an in-cluster service, run the CLI inside a pod.
+To check connectivity to an in-cluster service, run the check from inside the cluster. See [Run this check inside the cluster](#run-this-check-inside-the-cluster) below.
 
 ## Parameters
 
@@ -53,7 +53,7 @@ spec:
 
 ## Run this check inside the cluster
 
-By default the `mysql` collector connects from the machine running the CLI, so it tests connectivity from there rather than from inside the cluster. To run the connection check from _inside_ the cluster, run it as a Pod using the [`runPod`](/docs/collect/run-pod) collector with the Troubleshoot image (`replicated/troubleshoot`, v0.131.0 or later) and the `collect mysql` subcommand. The Pod runs the collector from within the cluster and prints the same result JSON to its logs, which you evaluate with [`textAnalyze`](/docs/analyze/regex):
+By default the `mysql` collector uses the network of the process running the CLI (see above). To run the connection check from _inside_ the cluster, run it as a Pod using the [`runPod`](/docs/collect/run-pod) collector with the Troubleshoot image (`proxy.replicated.com/library/troubleshoot`, v0.131.0 or later) and the `collect mysql` subcommand. The Pod runs the collector from within the cluster and prints the same result JSON to its logs, which you evaluate with [`textAnalyze`](/docs/analyze/regex):
 
 ```yaml
 collectors:
@@ -64,7 +64,7 @@ collectors:
         restartPolicy: Never
         containers:
           - name: check
-            image: replicated/troubleshoot:v0.131.0
+            image: proxy.replicated.com/library/troubleshoot:v0.131.0
             command: ["collect", "mysql", "--uri", "user:pass@tcp(my-db.default.svc.cluster.local:3306)/app"]
 analyzers:
   - textAnalyze:

--- a/docs/collect/mysql.md
+++ b/docs/collect/mysql.md
@@ -51,6 +51,38 @@ spec:
 ```
 
 
+## Run this check inside the cluster
+
+By default the `mysql` collector connects from the machine running the CLI, so it tests connectivity from there rather than from inside the cluster. To run the connection check from _inside_ the cluster, run it as a Pod using the [`runPod`](/docs/collect/run-pod) collector with the Troubleshoot image (`replicated/troubleshoot`, v0.131.0 or later) and the `collect mysql` subcommand. The Pod runs the collector from within the cluster and prints the same result JSON to its logs, which you evaluate with [`textAnalyze`](/docs/analyze/regex):
+
+```yaml
+collectors:
+  - runPod:
+      name: mysql-check
+      namespace: default
+      podSpec:
+        restartPolicy: Never
+        containers:
+          - name: check
+            image: replicated/troubleshoot:v0.131.0
+            command: ["collect", "mysql", "--uri", "user:pass@tcp(my-db.default.svc.cluster.local:3306)/app"]
+analyzers:
+  - textAnalyze:
+      checkName: MySQL reachable
+      collectorName: mysql-check
+      fileName: "*.log"
+      regex: '"isConnected":true'
+      outcomes:
+        - pass:
+            when: "true"
+            message: "Connected to MySQL from inside the cluster."
+        - fail:
+            when: "false"
+            message: "Could not connect to MySQL from inside the cluster."
+```
+
+Note that `--uri` is a Go MySQL driver DSN (`user:pass@tcp(host:3306)/db`), not a URL. In addition to `--uri` (required) and the TLS flags (`--tls-cacert`, `--tls-client-cert`, `--tls-client-key`, `--tls-skip-verify`, `--tls-secret-name`, `--tls-secret-namespace`), `collect mysql` accepts `--parameters` to collect server variables via `SHOW VARIABLES` (returned under `variables` in the result).
+
 ## Included resources
 
 A single JSON file will be added to the support bundle, in the path `/mysql/[collector-name].json`:

--- a/docs/collect/postgresql.md
+++ b/docs/collect/postgresql.md
@@ -147,6 +147,38 @@ spec:
           skipVerify: true
 ```
 
+## Run this check inside the cluster
+
+By default the `postgres` collector connects from the machine running the CLI, so it tests connectivity from there rather than from inside the cluster. To run the connection check from _inside_ the cluster, run it as a Pod using the [`runPod`](/docs/collect/run-pod) collector with the Troubleshoot image (`replicated/troubleshoot`, v0.131.0 or later) and the `collect postgres` subcommand. The Pod runs the collector from within the cluster and prints the same result JSON to its logs, which you evaluate with [`textAnalyze`](/docs/analyze/regex):
+
+```yaml
+collectors:
+  - runPod:
+      name: postgres-check
+      namespace: default
+      podSpec:
+        restartPolicy: Never
+        containers:
+          - name: check
+            image: replicated/troubleshoot:v0.131.0
+            command: ["collect", "postgres", "--uri", "postgres://user:pass@my-db.default.svc.cluster.local:5432/app?sslmode=disable"]
+analyzers:
+  - textAnalyze:
+      checkName: PostgreSQL reachable
+      collectorName: postgres-check
+      fileName: "*.log"
+      regex: '"isConnected":true'
+      outcomes:
+        - pass:
+            when: "true"
+            message: "Connected to PostgreSQL from inside the cluster."
+        - fail:
+            when: "false"
+            message: "Could not connect to PostgreSQL from inside the cluster."
+```
+
+The `collect postgres` subcommand accepts `--uri` (required) plus the TLS flags `--tls-cacert`, `--tls-client-cert`, `--tls-client-key`, `--tls-skip-verify`, `--tls-secret-name`, and `--tls-secret-namespace`, which map to the `uri` and `tls` parameters above. `--tls-secret-name` reads a Secret and requires cluster access.
+
 ## Included resources
 
 A single JSON file will be added to the support bundle, in the path `/postgres/[collector-name].json`:

--- a/docs/collect/postgresql.md
+++ b/docs/collect/postgresql.md
@@ -167,7 +167,7 @@ analyzers:
       checkName: PostgreSQL reachable
       collectorName: postgres-check
       fileName: "*.log"
-      regex: '"isConnected":true'
+      regex: '"isConnected": *true'
       outcomes:
         - pass:
             when: "true"

--- a/docs/collect/postgresql.md
+++ b/docs/collect/postgresql.md
@@ -11,7 +11,7 @@ The collector uses the network of the process running the support bundle CLI.
 - **Inside a pod:** requests use cluster networking, and in-cluster DNS (e.g. `*.svc.cluster.local`) resolves.
 - **Outside the cluster (CI runners, local machines):** requests use the host network, and in-cluster DNS names will not resolve.
 
-To check connectivity to an in-cluster service, run the CLI inside a pod.
+To check connectivity to an in-cluster service, run the check from inside the cluster. See [Run this check inside the cluster](#run-this-check-inside-the-cluster) below.
 
 ## Parameters
 
@@ -149,7 +149,7 @@ spec:
 
 ## Run this check inside the cluster
 
-By default the `postgres` collector connects from the machine running the CLI, so it tests connectivity from there rather than from inside the cluster. To run the connection check from _inside_ the cluster, run it as a Pod using the [`runPod`](/docs/collect/run-pod) collector with the Troubleshoot image (`replicated/troubleshoot`, v0.131.0 or later) and the `collect postgres` subcommand. The Pod runs the collector from within the cluster and prints the same result JSON to its logs, which you evaluate with [`textAnalyze`](/docs/analyze/regex):
+By default the `postgres` collector uses the network of the process running the CLI (see above). To run the connection check from _inside_ the cluster, run it as a Pod using the [`runPod`](/docs/collect/run-pod) collector with the Troubleshoot image (`proxy.replicated.com/library/troubleshoot`, v0.131.0 or later) and the `collect postgres` subcommand. The Pod runs the collector from within the cluster and prints the same result JSON to its logs, which you evaluate with [`textAnalyze`](/docs/analyze/regex):
 
 ```yaml
 collectors:
@@ -160,7 +160,7 @@ collectors:
         restartPolicy: Never
         containers:
           - name: check
-            image: replicated/troubleshoot:v0.131.0
+            image: proxy.replicated.com/library/troubleshoot:v0.131.0
             command: ["collect", "postgres", "--uri", "postgres://user:pass@my-db.default.svc.cluster.local:5432/app?sslmode=disable"]
 analyzers:
   - textAnalyze:

--- a/docs/collect/redis.md
+++ b/docs/collect/redis.md
@@ -11,7 +11,7 @@ The collector uses the network of the process running the support bundle CLI.
 - **Inside a pod:** requests use cluster networking, and in-cluster DNS (e.g. `*.svc.cluster.local`) resolves.
 - **Outside the cluster (CI runners, local machines):** requests use the host network, and in-cluster DNS names will not resolve.
 
-To check connectivity to an in-cluster service, run the CLI inside a pod.
+To check connectivity to an in-cluster service, run the check from inside the cluster. See [Run this check inside the cluster](#run-this-check-inside-the-cluster) below.
 
 ## Parameters
 
@@ -135,7 +135,7 @@ spec:
 
 ## Run this check inside the cluster
 
-By default the `redis` collector connects from the machine running the CLI, so it tests connectivity from there rather than from inside the cluster. To run the connection check from _inside_ the cluster, run it as a Pod using the [`runPod`](/docs/collect/run-pod) collector with the Troubleshoot image (`replicated/troubleshoot`, v0.131.0 or later) and the `collect redis` subcommand. The Pod runs the collector from within the cluster and prints the same result JSON to its logs, which you evaluate with [`textAnalyze`](/docs/analyze/regex):
+By default the `redis` collector uses the network of the process running the CLI (see above). To run the connection check from _inside_ the cluster, run it as a Pod using the [`runPod`](/docs/collect/run-pod) collector with the Troubleshoot image (`proxy.replicated.com/library/troubleshoot`, v0.131.0 or later) and the `collect redis` subcommand. The Pod runs the collector from within the cluster and prints the same result JSON to its logs, which you evaluate with [`textAnalyze`](/docs/analyze/regex):
 
 ```yaml
 collectors:
@@ -146,7 +146,7 @@ collectors:
         restartPolicy: Never
         containers:
           - name: check
-            image: replicated/troubleshoot:v0.131.0
+            image: proxy.replicated.com/library/troubleshoot:v0.131.0
             command: ["collect", "redis", "--uri", "redis://my-cache.default.svc.cluster.local:6379"]
 analyzers:
   - textAnalyze:

--- a/docs/collect/redis.md
+++ b/docs/collect/redis.md
@@ -153,7 +153,7 @@ analyzers:
       checkName: Redis reachable
       collectorName: redis-check
       fileName: "*.log"
-      regex: '"isConnected":true'
+      regex: '"isConnected": *true'
       outcomes:
         - pass:
             when: "true"

--- a/docs/collect/redis.md
+++ b/docs/collect/redis.md
@@ -133,6 +133,38 @@ spec:
           skipVerify: true
 ```
 
+## Run this check inside the cluster
+
+By default the `redis` collector connects from the machine running the CLI, so it tests connectivity from there rather than from inside the cluster. To run the connection check from _inside_ the cluster, run it as a Pod using the [`runPod`](/docs/collect/run-pod) collector with the Troubleshoot image (`replicated/troubleshoot`, v0.131.0 or later) and the `collect redis` subcommand. The Pod runs the collector from within the cluster and prints the same result JSON to its logs, which you evaluate with [`textAnalyze`](/docs/analyze/regex):
+
+```yaml
+collectors:
+  - runPod:
+      name: redis-check
+      namespace: default
+      podSpec:
+        restartPolicy: Never
+        containers:
+          - name: check
+            image: replicated/troubleshoot:v0.131.0
+            command: ["collect", "redis", "--uri", "redis://my-cache.default.svc.cluster.local:6379"]
+analyzers:
+  - textAnalyze:
+      checkName: Redis reachable
+      collectorName: redis-check
+      fileName: "*.log"
+      regex: '"isConnected":true'
+      outcomes:
+        - pass:
+            when: "true"
+            message: "Connected to Redis from inside the cluster."
+        - fail:
+            when: "false"
+            message: "Could not connect to Redis from inside the cluster."
+```
+
+The `collect redis` subcommand accepts `--uri` (required) plus the TLS flags `--tls-cacert`, `--tls-client-cert`, `--tls-client-key`, `--tls-skip-verify`, `--tls-secret-name`, and `--tls-secret-namespace`, which map to the `uri` and `tls` parameters above.
+
 ## Included resources
 
 A single JSON file will be added to the support bundle, in the path `/redis/[collector-name].json`:


### PR DESCRIPTION
## What
Adds a "Run this check inside the cluster" section to each connectivity collector
page: `http`, `postgres`, `mysql`, `mssql`, `redis`, and `clickhouse`.

## Why
These collectors run wherever the CLI runs, so they test connectivity from that
machine rather than from inside the cluster. The `collect <name>` subcommands
(released in v0.131.0) let you run a single collector inside a Pod via a `runPod`
collector, so the check executes from within the cluster.

## Notes
- Each section shows the `runPod` + `collect <name>` pattern, a `textAnalyze`
  example matching the native result JSON, and that collector's supported flags.
- Documented per-collector rather than in a central page, since the subcommands
  exist only for these connectivity collectors.
