### PR TITLE
docs(runpod): clarify that runPod status JSON omits the pod spec

### DIFF
--- a/docs/collect/run-pod.md
+++ b/docs/collect/run-pod.md
@@ -138,7 +138,8 @@ This will contain the pod output (up to 10000 lines).
 
 ### `/[collector-name]/[collector-name].json`
 
-This will contain the pod status details in JSON format.
+This will contain the pod metadata and status (phase, conditions, container statuses, etc.) in JSON format.
+The pod `Spec` is intentionally omitted to avoid persisting sensitive data such as environment variables, commands, args, and image pull secrets in the collected bundle.
 
 ### `/[collector-name]/[collector-name]-events.json`
 


### PR DESCRIPTION
Updates the runPod collector docs to clarify that /[collector-name]/[collector-name].json contains pod metadata and status, but not the Spec, so sensitive data from podSpec (env vars, commands, args, image pull secrets, etc.) is not persisted in the bundle.