### PR TITLE
docs: document --redactors flag and secret/configmap URI support

### DIFF
--- a/docs/support-bundle/collecting.md
+++ b/docs/support-bundle/collecting.md
@@ -61,6 +61,39 @@ kubectl support-bundle https://raw.githubusercontent.com/replicatedhq/troublesho
 secret/path/to/my/spec
 ```
 
+## Apply custom redactors from files, URLs, or cluster resources
+
+In addition to the built-in redactors, you can apply one or more custom `Redactor` specs by passing them with the `--redactors` flag. The flag can be specified multiple times.
+
+Each value can be one of the following:
+
+- A local file path
+- An HTTP or HTTPS URL
+- An `oci://` registry URL
+- A ConfigMap URI: `configmap/<namespace>/<configmap-name>[/<data-key>]`
+- A Secret URI: `secret/<namespace>/<secret-name>[/<data-key>]`
+
+The default data key is `redactor-spec`.
+
+### Examples
+
+Apply redactors from a local file and a Secret:
+
+```shell
+kubectl support-bundle ./support-bundle.yaml \
+  --redactors ./my-redactor.yaml \
+  --redactors secret/default/my-redactor
+```
+
+Apply a redactor from a ConfigMap with a custom data key:
+
+```shell
+kubectl support-bundle ./support-bundle.yaml \
+  --redactors configmap/default/my-redactor/custom-key
+```
+
+For more information about writing redactor specs, see [Redactors](/docs/redact/redactors).
+
 ## Collect a support bundle using specs discovered from the cluster
 
 > Introduced in Troubleshoot v0.47.0


### PR DESCRIPTION
## Summary

Documents the `support-bundle` CLI `--redactors` flag and the supported URI formats, including the new `secret/...` support for redactor specs introduced in https://github.com/replicatedhq/troubleshoot/pull/2111.

## Changes

- Added a new section to `docs/support-bundle/collecting.md`: **"Apply custom redactors from files, URLs, or cluster resources"`.
- Documents the supported `--redactors` values: local files, HTTP/HTTPS URLs, `oci://` URLs, and `configmap/...` and `secret/...` cluster resource URIs.
- Notes the default data key for cluster resource redactors is `redactor-spec`, and that a custom key can be appended to the URI.

## Related

- Troubleshoot PR: https://github.com/replicatedhq/troubleshoot/pull/2111
- KOTS story: https://app.shortcut.com/replicated/story/139291
